### PR TITLE
Prevent performing menu actions when no item selected to prevent crash.

### DIFF
--- a/Doughnut/View Controllers/EpisodeViewController.swift
+++ b/Doughnut/View Controllers/EpisodeViewController.swift
@@ -211,33 +211,33 @@ class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTableViewD
     return true
   }
 
-  func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-    if tableView.clickedRow < 0 {
-        return false
+  @objc func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+    guard tableView.clickedRow != -1, tableView.clickedRow < episodes.count else {
+      return false
     }
 
     let episode = episodes[tableView.clickedRow]
 
-    switch menuItem.title {
-    case "Play Now":
+    switch menuItem.action {
+    case #selector(playNow(_:)):
       return true
-    case "Mark as Played":
+    case #selector(markAsPlayed(_:)):
       return !episode.played
-    case "Mark as Unplayed":
+    case #selector(markAsUnplayed(_:)):
       return episode.played
-    case "Mark as Favourite":
+    case #selector(markAsFavourite(_:)):
       return !episode.favourite
-    case "Unmark Favourite":
+    case #selector(unmarkAsFavourite(_:)):
       return episode.favourite
-    case "Delete Episode":
+    case #selector(deleteEpisode(_:)):
       return true
-    case "Download":
+    case #selector(download(_:)):
       return episode.enclosureUrl != nil && !episode.downloaded
-    case "Move to Trash":
+    case #selector(moveToTrash(_:)):
       return episode.downloaded
-    case "Show Episode":
+    case #selector(showEpisode(_:)):
       return true
-    case "Show in Finder":
+    case #selector(showInFinder(_:)):
       return episode.downloaded
     default:
       return false

--- a/Doughnut/View Controllers/PodcastViewController.swift
+++ b/Doughnut/View Controllers/PodcastViewController.swift
@@ -235,10 +235,14 @@ class PodcastViewController: NSViewController, NSTableViewDelegate, NSTableViewD
     Library.global.reloadAll()
   }
 
-  func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-    if tableView.clickedRow < 0 && menuItem.title != "Refresh All" {
-      return false
+  @objc func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+    if menuItem.action == #selector(refreshAll(_:)) {
+      return true
     }
-    return true
+    if tableView.clickedRow != -1 {
+      return true
+    }
+    return false
   }
+
 }

--- a/Doughnut/Windows/ShowPodcastWindow.swift
+++ b/Doughnut/Windows/ShowPodcastWindow.swift
@@ -193,7 +193,7 @@ class ShowPodcastViewController: NSViewController {
     if let podcast = podcast {
       commitChanges(podcast)
 
-      if validate() {
+      if Self.validate(forPodcast: podcast) {
         Library.global.save(podcast: podcast)
         NSApp.stopModal(withCode: .OK)
         view.window?.close()
@@ -203,7 +203,7 @@ class ShowPodcastViewController: NSViewController {
       let podcast = Podcast(title: titleInputView.stringValue)
       commitChanges(podcast)
 
-      if validate() {
+      if Self.validate(forPodcast: podcast) {
         Library.global.subscribe(podcast: podcast)
         NSApp.stopModal(withCode: .OK)
         view.window?.close()
@@ -239,9 +239,7 @@ class ShowPodcastViewController: NSViewController {
     }
   }
 
-  func validate() -> Bool {
-    guard let podcast = podcast else { return false }
-
+  static func validate(forPodcast podcast: Podcast) -> Bool {
     if let invalid = podcast.invalid() {
       let alert = NSAlert()
       alert.messageText = "Unable to Save Podcast"
@@ -253,4 +251,5 @@ class ShowPodcastViewController: NSViewController {
       return true
     }
   }
+
 }


### PR DESCRIPTION
This should actually fix #25.

This PR fixes crash caused by performing menu actions when no podcast or episode selected.

1. Use `@objc` to modify `validateMenuItem(_: NSMenuItem)` to ensure they're called by AppKit.
2. Instead matching menuItem with `title`, match them with `action`, strings are fragile (or maybe error prone).
3. Fixed an issue found during debugging: can't create new podcast due to `nil` passed into `ShowPodcastViewController.validate(_:)`.