### PR TITLE
Fix: choosing manual reload in preference not taking effect

### DIFF
--- a/Doughnut/Library/Library.swift
+++ b/Doughnut/Library/Library.swift
@@ -350,7 +350,7 @@ class Library: NSObject {
     }
 
     // Reload podcasts on the default schedule
-    if (minutesSinceLastScheduledReload >= reloadFrequency) {
+    if (reloadFrequency != -1 && minutesSinceLastScheduledReload >= reloadFrequency) {
       for podcast in podcasts {
         if podcast.defaultReload {
           reload(podcast: podcast, onQueue: backgroundQueue)

--- a/Doughnut/Preference/Preferences.storyboard
+++ b/Doughnut/Preference/Preferences.storyboard
@@ -134,7 +134,7 @@
                                                 <modifierMask key="keyEquivalentModifierMask"/>
                                             </menuItem>
                                             <menuItem isSeparatorItem="YES" id="vtl-Rc-0YD"/>
-                                            <menuItem title="Manually" id="9Hr-fP-57g">
+                                            <menuItem title="Manually" tag="-1" id="9Hr-fP-57g">
                                                 <modifierMask key="keyEquivalentModifierMask"/>
                                             </menuItem>
                                         </items>


### PR DESCRIPTION
This PR fixes #22 by using `-1` as the tag for "Manually" menu option and add a specific check.
Previously "Manually" has a same tag `0` with the separator, this results the separator chosen when reopening the preference panel and, actually, podcasts got refreshed once per minute. 