### PR TITLE
Enhancements for menu actions and shortcuts.

### DIFF
--- a/Doughnut.xcodeproj/project.pbxproj
+++ b/Doughnut.xcodeproj/project.pbxproj
@@ -10,6 +10,8 @@
 		1D7B5D7B127AE8F635350D7F /* Pods_DoughnutTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 558EE5E875BAF91152803575 /* Pods_DoughnutTests.framework */; };
 		2AB07BF789841271ED80EA26 /* Pods_DoughnutUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25D4796441E8F7922FCDAF9A /* Pods_DoughnutUITests.framework */; };
 		4125A143137AD05319B3DEFC /* Pods_Doughnut.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2661E19A57B17099FC4ECCDD /* Pods_Doughnut.framework */; };
+		6B0605C52788627D00A8A91E /* NSMenu+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0605C42788627D00A8A91E /* NSMenu+Extensions.swift */; };
+		6B94DF4C278968F500BCB149 /* NSTableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B94DF4B278968F500BCB149 /* NSTableView+Extensions.swift */; };
 		6BB5771E278602B400DFF99F /* MainMenu.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6BB5771C278602B400DFF99F /* MainMenu.storyboard */; };
 		6BF126D12780727100D840A4 /* EpisodeInfo.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6BF126D02780727100D840A4 /* EpisodeInfo.storyboard */; };
 		6BF126D32780742600D840A4 /* PodcastInfo.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6BF126D22780742600D840A4 /* PodcastInfo.storyboard */; };
@@ -172,8 +174,10 @@
 		368B5540FC7D1B6258BCF776 /* Pods-DoughnutUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DoughnutUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DoughnutUITests/Pods-DoughnutUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		558EE5E875BAF91152803575 /* Pods_DoughnutTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DoughnutTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E1DC050EEE121FD033C44DF /* Pods-Doughnut.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Doughnut.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Doughnut/Pods-Doughnut.debug.xcconfig"; sourceTree = "<group>"; };
+		6B0605C42788627D00A8A91E /* NSMenu+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMenu+Extensions.swift"; sourceTree = "<group>"; };
 		6B3ACC982773555700CF1EF1 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		6B730B732767A90900FB5F84 /* Doughnut-Release.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Doughnut-Release.entitlements"; sourceTree = "<group>"; };
+		6B94DF4B278968F500BCB149 /* NSTableView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTableView+Extensions.swift"; sourceTree = "<group>"; };
 		6BB5771D278602B400DFF99F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainMenu.storyboard; sourceTree = "<group>"; };
 		6BF126D02780727100D840A4 /* EpisodeInfo.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = EpisodeInfo.storyboard; sourceTree = "<group>"; };
 		6BF126D22780742600D840A4 /* PodcastInfo.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = PodcastInfo.storyboard; sourceTree = "<group>"; };
@@ -280,6 +284,31 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		6B0605BF2788624B00A8A91E /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				6B0605C22788626600A8A91E /* Extensions */,
+			);
+			path = Utilities;
+			sourceTree = "<group>";
+		};
+		6B0605C22788626600A8A91E /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				6B0605C32788626F00A8A91E /* AppKit */,
+			);
+			name = Extensions;
+			sourceTree = "<group>";
+		};
+		6B0605C32788626F00A8A91E /* AppKit */ = {
+			isa = PBXGroup;
+			children = (
+				6B0605C42788627D00A8A91E /* NSMenu+Extensions.swift */,
+				6B94DF4B278968F500BCB149 /* NSTableView+Extensions.swift */,
+			);
+			name = AppKit;
+			sourceTree = "<group>";
+		};
 		6F37DC96B4D6909BC9F7B09C /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -413,6 +442,7 @@
 				83667DEE1F76D1F300F1ABC0 /* View Controllers */,
 				839DBDA51FEEE872007610EF /* Windows */,
 				83235BF5200945D900BC356F /* Preference */,
+				6B0605BF2788624B00A8A91E /* Utilities */,
 				838257CD1F759F6F00DB4FD1 /* AppDelegate.swift */,
 				83BA22E21F994EA6006BF58A /* DoughnutApp.swift */,
 				83D971091F812B270091822A /* Player.swift */,
@@ -812,6 +842,7 @@
 				83667DF01F76D20C00F1ABC0 /* PodcastViewController.swift in Sources */,
 				83D9710C1F812E910091822A /* PlayerView.swift in Sources */,
 				83235C042009473200BC356F /* PrefLibraryViewController.swift in Sources */,
+				6B0605C52788627D00A8A91E /* NSMenu+Extensions.swift in Sources */,
 				839DBDA41FEEE658007610EF /* ShowPodcastWindow.swift in Sources */,
 				83D9710A1F812B270091822A /* Player.swift in Sources */,
 				83EFC6041F9954A500E1DE1F /* SPMediaKeyTap.m in Sources */,
@@ -820,6 +851,7 @@
 				83504DD61FFC377700375BA0 /* EpisodeDownloadTask.swift in Sources */,
 				83BA22E31F994EA6006BF58A /* DoughnutApp.swift in Sources */,
 				832A04341F76EBDC00C92D25 /* WindowController.swift in Sources */,
+				6B94DF4C278968F500BCB149 /* NSTableView+Extensions.swift in Sources */,
 				830B159B1F7B97910086C121 /* PodcastCellView.swift in Sources */,
 				83235C072009473500BC356F /* PrefPlaybackViewController.swift in Sources */,
 				830E99BD1FF50DD000B728BE /* ActivityIndicator.swift in Sources */,

--- a/Doughnut/AppDelegate.swift
+++ b/Doughnut/AppDelegate.swift
@@ -125,4 +125,32 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   @IBAction func showPreferences(_ sender: AnyObject) {
     preferencesWindowController.showWindow(self)
   }
+
+  @IBAction func rename(_ sender: AnyObject) {
+    assert(false, "This menu item is to be implemented: \(#function)")
+  }
+
+  @IBAction func deleteAllPlayed(_ sender: AnyObject) {
+    assert(false, "This menu item is to be implemented: \(#function)")
+  }
+
+  @objc func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+    // Hide main menu items that is not impelemented for release build.
+    switch menuItem.action {
+    case #selector(rename(_:)):
+#if !DEBUG
+      menuItem.isHidden = true
+#endif
+      break
+    case #selector(deleteAllPlayed(_:)):
+#if !DEBUG
+      menuItem.isHidden = true
+#endif
+      break
+    default:
+      break
+    }
+    return true
+  }
+
 }

--- a/Doughnut/Base.lproj/Main.storyboard
+++ b/Doughnut/Base.lproj/Main.storyboard
@@ -557,7 +557,7 @@ Gw
                                     <rect key="frame" x="0.0" y="0.0" width="331" height="400"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="76" viewBased="YES" id="Xrx-cp-IWJ">
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" autosaveColumns="NO" rowHeight="76" viewBased="YES" id="Xrx-cp-IWJ">
                                             <rect key="frame" x="0.0" y="0.0" width="331" height="400"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/Doughnut/Base.lproj/Main.storyboard
+++ b/Doughnut/Base.lproj/Main.storyboard
@@ -356,7 +356,7 @@ Gw
                                     <rect key="frame" x="0.0" y="0.0" width="231" height="401"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="55" viewBased="YES" id="aVy-1A-ODd">
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnSelection="YES" columnResizing="NO" autosaveColumns="NO" rowHeight="55" viewBased="YES" id="aVy-1A-ODd">
                                             <rect key="frame" x="0.0" y="0.0" width="231" height="401"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <size key="intercellSpacing" width="0.0" height="4"/>

--- a/Doughnut/Base.lproj/MainMenu.storyboard
+++ b/Doughnut/Base.lproj/MainMenu.storyboard
@@ -331,26 +331,45 @@
                                             <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="mGw-AR-fTX"/>
-                                        <menuItem title="Play Now" keyEquivalent="p" id="Uoq-Ng-H9L"/>
+                                        <menuItem title="Play Now" keyEquivalent="p" id="Uoq-Ng-H9L">
+                                            <connections>
+                                                <action selector="playNow:" target="Ady-hI-5gd" id="OZl-G6-iyi"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="MW8-7q-b1c"/>
                                         <menuItem title="Mark as Played" keyEquivalent="m" id="sD6-MD-JPa">
                                             <modifierMask key="keyEquivalentModifierMask" control="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="togglePlayed:" target="Ady-hI-5gd" id="L2N-rs-UUC"/>
+                                            </connections>
                                         </menuItem>
-                                        <menuItem title="Mark as Unplayed" keyEquivalent="M" id="LQ2-01-YsU"/>
-                                        <menuItem title="Mark as Favourite" keyEquivalent="b" id="YGQ-dO-zxl"/>
-                                        <menuItem title="Unmark Favourite" keyEquivalent="B" id="2XW-mi-VBH"/>
+                                        <menuItem title="Mark as Favourite" keyEquivalent="b" id="YGQ-dO-zxl">
+                                            <connections>
+                                                <action selector="toggleFavourite:" target="Ady-hI-5gd" id="VUd-Rv-Fbk"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="anr-AG-0sS"/>
-                                        <menuItem title="Mark all as Played" id="1nS-fp-Zqn">
+                                        <menuItem title="Mark All as Played" id="1nS-fp-Zqn">
                                             <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="markAllAsPlayed:" target="Ady-hI-5gd" id="d0l-SO-2bq"/>
+                                            </connections>
                                         </menuItem>
-                                        <menuItem title="Mark all as Unplayed" id="1ZI-AO-bKd">
+                                        <menuItem title="Mark All as Unplayed" id="1ZI-AO-bKd">
                                             <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="markAllAsUnplayed:" target="Ady-hI-5gd" id="bOV-jv-7hS"/>
+                                            </connections>
                                         </menuItem>
-                                        <menuItem title="Delete all Played" id="Jry-P3-Eq0">
+                                        <menuItem title="Delete All Played" id="Jry-P3-Eq0">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="8dx-2Z-yrg"/>
-                                        <menuItem title="Download" keyEquivalent="l" id="Wn0-fi-sPT"/>
+                                        <menuItem title="Download" keyEquivalent="l" id="Wn0-fi-sPT">
+                                            <connections>
+                                                <action selector="downloadEpisode:" target="Ady-hI-5gd" id="hJr-Jv-VEw"/>
+                                            </connections>
+                                        </menuItem>
                                     </items>
                                 </menu>
                             </menuItem>

--- a/Doughnut/Base.lproj/MainMenu.storyboard
+++ b/Doughnut/Base.lproj/MainMenu.storyboard
@@ -74,14 +74,12 @@
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="File" id="bib-Uj-vzu">
                                     <items>
-                                        <menuItem title="Subscribe to Podcast" id="lgi-VV-buh">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                        <menuItem title="Subscribe to Podcast" keyEquivalent="n" id="lgi-VV-buh">
                                             <connections>
                                                 <action selector="subscribeToPodcast:" target="Ady-hI-5gd" id="Nrj-bB-7WF"/>
                                             </connections>
                                         </menuItem>
-                                        <menuItem title="New Podcast" id="r57-2i-B99">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                        <menuItem title="New Podcast" keyEquivalent="N" id="r57-2i-B99">
                                             <connections>
                                                 <action selector="newPodcast:" target="Ady-hI-5gd" id="KXx-5u-PuP"/>
                                             </connections>
@@ -138,7 +136,9 @@
                                             </connections>
                                         </menuItem>
                                         <menuItem title="Delete" id="pa3-QI-u2k">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <string key="keyEquivalent" base64-UTF8="YES">
+CA
+</string>
                                             <connections>
                                                 <action selector="delete:" target="Ady-hI-5gd" id="0Mk-Ml-PaM"/>
                                             </connections>
@@ -334,6 +334,11 @@
                                             <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
                                             <connections>
                                                 <action selector="reloadPodcast:" target="Ady-hI-5gd" id="G9N-aZ-Xec"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Get Info" keyEquivalent="i" id="4kt-61-eYA">
+                                            <connections>
+                                                <action selector="getInfo:" target="Ady-hI-5gd" id="Af0-oA-5H7"/>
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="mGw-AR-fTX"/>

--- a/Doughnut/Base.lproj/MainMenu.storyboard
+++ b/Doughnut/Base.lproj/MainMenu.storyboard
@@ -326,6 +326,9 @@
                                     <items>
                                         <menuItem title="Rename" id="Pr3-Z8-FZ1">
                                             <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="rename:" target="Ady-hI-5gd" id="Ahp-Mo-eVa"/>
+                                            </connections>
                                         </menuItem>
                                         <menuItem title="Reload" keyEquivalent="r" id="6GL-kM-gC5">
                                             <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
@@ -366,6 +369,9 @@
                                         </menuItem>
                                         <menuItem title="Delete All Played" id="Jry-P3-Eq0">
                                             <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="deleteAllPlayed:" target="Ady-hI-5gd" id="O6A-7A-elP"/>
+                                            </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="8dx-2Z-yrg"/>
                                         <menuItem title="Download" keyEquivalent="l" id="Wn0-fi-sPT">

--- a/Doughnut/Base.lproj/MainMenu.storyboard
+++ b/Doughnut/Base.lproj/MainMenu.storyboard
@@ -329,6 +329,9 @@
                                         </menuItem>
                                         <menuItem title="Reload" keyEquivalent="r" id="6GL-kM-gC5">
                                             <modifierMask key="keyEquivalentModifierMask" option="YES" command="YES"/>
+                                            <connections>
+                                                <action selector="reloadPodcast:" target="Ady-hI-5gd" id="G9N-aZ-Xec"/>
+                                            </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="mGw-AR-fTX"/>
                                         <menuItem title="Play Now" keyEquivalent="p" id="Uoq-Ng-H9L">

--- a/Doughnut/Utilities/NSMenu+Extensions.swift
+++ b/Doughnut/Utilities/NSMenu+Extensions.swift
@@ -1,0 +1,60 @@
+/*
+ * Doughnut Podcast Client
+ * Copyright (C) 2022 Ethan Wong
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import AppKit
+
+extension NSMenu {
+
+  enum MenuType {
+    case main
+    case dock
+    case contextual
+  }
+
+  var menuType: MenuType {
+    let topMenu = topMenu
+    if topMenu == NSApp.mainMenu {
+      return .main
+    } else if topMenu == NSApp.delegate?.applicationDockMenu?(NSApp) {
+      return .dock
+    } else {
+      return .contextual
+    }
+  }
+
+  var topMenu: NSMenu {
+    var current: NSMenu? = self
+    while current?.supermenu != nil {
+      current = current?.supermenu
+    }
+    return current!
+  }
+
+}
+
+extension NSMenuItem {
+
+  var topMenu: NSMenu? {
+    return menu?.topMenu
+  }
+
+  var menuType: NSMenu.MenuType? {
+    return menu?.menuType
+  }
+
+}

--- a/Doughnut/Utilities/NSTableView+Extensions.swift
+++ b/Doughnut/Utilities/NSTableView+Extensions.swift
@@ -1,0 +1,30 @@
+/*
+ * Doughnut Podcast Client
+ * Copyright (C) 2022 Ethan Wong
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import AppKit
+
+extension NSTableView {
+
+  var activeRowIndices: IndexSet {
+    if clickedRow != -1, !selectedRowIndexes.contains(clickedRow) {
+      return [clickedRow]
+    }
+    return selectedRowIndexes
+  }
+
+}

--- a/Doughnut/View Controllers/EpisodeViewController.swift
+++ b/Doughnut/View Controllers/EpisodeViewController.swift
@@ -220,6 +220,8 @@ class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTableViewD
     switch menuItem.action {
     case #selector(playNow(_:)):
       return episodes.count == 1
+    case #selector(getInfo(_:)):
+      fallthrough
     case #selector(showEpisode(_:)):
       return episodes.count == 1
     case #selector(togglePlayed(_:)):
@@ -254,6 +256,8 @@ class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTableViewD
     case #selector(showInFinder(_:)):
       menuItem.isHidden = allowHidingMenuItem && episodes.count != 1
       return episodes.count == 1 && episodes.first!.downloaded
+    case #selector(delete(_:)):
+      fallthrough
     case #selector(deleteEpisode(_:)):
       menuItem.isHidden = allowHidingMenuItem && episodes.count != 1
       return episodes.count == 1
@@ -343,6 +347,10 @@ class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTableViewD
     Library.global.save(episode: episode)
   }
 
+  @IBAction func delete(_ sender: Any) {
+    deleteEpisode(sender)
+  }
+
   @IBAction func deleteEpisode(_ sender: Any) {
     let episodes = activeEpisodesForAction()
     assert(episodes.count == 1)
@@ -372,6 +380,10 @@ class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTableViewD
     } else {
       podcast.deleteEpisode(episode: episode)
     }
+  }
+
+  @IBAction func getInfo(_ sender: Any) {
+    showEpisode(sender)
   }
 
   @IBAction func showEpisode(_ sender: Any) {

--- a/Doughnut/View Controllers/PodcastViewController.swift
+++ b/Doughnut/View Controllers/PodcastViewController.swift
@@ -153,6 +153,12 @@ class PodcastViewController: NSViewController, NSTableViewDelegate, NSTableViewD
     return true
   }
 
+  private func activePodcastsForAction() -> [Podcast] {
+    return tableView.activeRowIndices.compactMap { rowIndex in
+      return rowIndex < podcasts.count ? podcasts[rowIndex] : nil
+    }
+  }
+
   func sorted(by: String?, direction: SortDirection) {
     if let sortParam = PodcastSortParameter(rawValue: by ?? "") {
       sortBy = sortParam
@@ -163,58 +169,79 @@ class PodcastViewController: NSViewController, NSTableViewDelegate, NSTableViewD
     reloadPodcasts()
   }
 
+  // MARK: - Actions
+
   @IBAction func reloadPodcast(_ sender: Any) {
-    Library.global.reload(podcast: podcasts[tableView.clickedRow])
+    let podcasts = activePodcastsForAction()
+    assert(podcasts.count == 1)
+    guard let podcast = podcasts.first else { return }
+
+    Library.global.reload(podcast: podcast)
   }
 
   @IBAction func podcastInfo(_ sender: Any) {
+    let podcasts = activePodcastsForAction()
+    assert(podcasts.count == 1)
+    guard let podcast = podcasts.first else { return }
+
     guard let podcastWindowController = ShowPodcastWindowController.instantiateFromMainStoryboard(),
           let podcastViewController = podcastWindowController.contentViewController as? ShowPodcastViewController,
           let podcastWindow = podcastWindowController.window
     else {
       return
     }
-    podcastViewController.podcast = podcasts[tableView.clickedRow]
+    podcastViewController.podcast = podcast
     NSApp.runModal(for: podcastWindow)
   }
 
   @IBAction func markAllAsPlayed(_ sender: Any) {
-    let podcast = podcasts[tableView.clickedRow]
+    let podcasts = activePodcastsForAction()
 
-    for episode in podcast.episodes {
-      episode.played = true
+    for podcast in podcasts {
+      for episode in podcast.episodes {
+        episode.played = true
+      }
+
+      // Manually trigger a view reload to make update seem instant
+      viewController.libraryUpdatedPodcast(podcast: podcast)
+
+      // Commit changes to library
+      Library.global.save(podcast: podcast)
     }
-
-    // Manually trigger a view reload to make update seem instant
-    viewController.libraryUpdatedPodcast(podcast: podcast)
-
-    // Commit changes to library
-    Library.global.save(podcast: podcast)
   }
 
   @IBAction func markAllAsUnplayed(_ sender: Any) {
-    let podcast = podcasts[tableView.clickedRow]
+    let podcasts = activePodcastsForAction()
 
-    for episode in podcast.episodes {
-      episode.played = false
+    for podcast in podcasts {
+      for episode in podcast.episodes {
+        episode.played = false
+      }
+
+      // Manually trigger a view reload to make update seem instant
+      viewController.libraryUpdatedPodcast(podcast: podcast)
+
+      // Commit changes to library
+      Library.global.save(podcast: podcast)
     }
-
-    // Manually trigger a view reload to make update seem instant
-    viewController.libraryUpdatedPodcast(podcast: podcast)
-
-    // Commit changes to library
-    Library.global.save(podcast: podcast)
   }
 
   @IBAction func copyPodcastURL(_ sender: Any) {
-    if let feed = podcasts[tableView.clickedRow].feed {
-      NSPasteboard.general.declareTypes([.string], owner: nil)
-      NSPasteboard.general.setString(feed, forType: .string)
+    let podcasts = activePodcastsForAction()
+    assert(podcasts.count == 1)
+
+    guard let podcast = podcasts.first, let feed = podcast.feed else {
+      return
     }
+
+    NSPasteboard.general.declareTypes([.string], owner: nil)
+    NSPasteboard.general.setString(feed, forType: .string)
   }
 
   @IBAction func unsubscribe(_ sender: Any) {
-    let podcast = podcasts[tableView.clickedRow]
+    let podcasts = activePodcastsForAction()
+    assert(podcasts.count == 1)
+    guard let podcast = podcasts.first else { return }
 
     let alert = NSAlert()
     alert.addButton(withTitle: "Leave Files")
@@ -236,13 +263,27 @@ class PodcastViewController: NSViewController, NSTableViewDelegate, NSTableViewD
   }
 
   @objc func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
-    if menuItem.action == #selector(refreshAll(_:)) {
+    let podcasts = activePodcastsForAction()
+
+    switch menuItem.action {
+    case #selector(reloadPodcast(_:)):
+      return podcasts.count == 1
+    case #selector(podcastInfo(_:)):
+      return podcasts.count == 1
+    case #selector(markAllAsPlayed(_:)):
+      return !podcasts.isEmpty
+    case #selector(markAllAsUnplayed(_:)):
+      return !podcasts.isEmpty
+    case #selector(copyPodcastURL(_:)):
+      return podcasts.count == 1
+    case #selector(unsubscribe(_:)):
+      return podcasts.count == 1
+    case #selector(refreshAll(_:)):
       return true
+    default:
+      assert(false, "Unhandled menu item in \(#function)")
+      return false
     }
-    if tableView.clickedRow != -1 {
-      return true
-    }
-    return false
   }
 
 }

--- a/Doughnut/View Controllers/PodcastViewController.swift
+++ b/Doughnut/View Controllers/PodcastViewController.swift
@@ -179,6 +179,10 @@ class PodcastViewController: NSViewController, NSTableViewDelegate, NSTableViewD
     Library.global.reload(podcast: podcast)
   }
 
+  @IBAction func getInfo(_ sender: Any) {
+    podcastInfo(sender)
+  }
+
   @IBAction func podcastInfo(_ sender: Any) {
     let podcasts = activePodcastsForAction()
     assert(podcasts.count == 1)
@@ -238,6 +242,10 @@ class PodcastViewController: NSViewController, NSTableViewDelegate, NSTableViewD
     NSPasteboard.general.setString(feed, forType: .string)
   }
 
+  @IBAction func delete(_ sender: Any) {
+    unsubscribe(sender)
+  }
+
   @IBAction func unsubscribe(_ sender: Any) {
     let podcasts = activePodcastsForAction()
     assert(podcasts.count == 1)
@@ -268,6 +276,8 @@ class PodcastViewController: NSViewController, NSTableViewDelegate, NSTableViewD
     switch menuItem.action {
     case #selector(reloadPodcast(_:)):
       return podcasts.count == 1
+    case #selector(getInfo(_:)):
+      fallthrough
     case #selector(podcastInfo(_:)):
       return podcasts.count == 1
     case #selector(markAllAsPlayed(_:)):
@@ -276,6 +286,8 @@ class PodcastViewController: NSViewController, NSTableViewDelegate, NSTableViewD
       return !podcasts.isEmpty
     case #selector(copyPodcastURL(_:)):
       return podcasts.count == 1
+    case #selector(delete(_:)):
+      fallthrough
     case #selector(unsubscribe(_:)):
       return podcasts.count == 1
     case #selector(refreshAll(_:)):


### PR DESCRIPTION
This PR  fixes #18, fixes #24, fixes #27, and fixes #29.

This PR contains enhancements and fixes for menus actions and shortcuts:

1. Allow bulk editing on podcasts list and episodes list. (Some actions are not supported currently, but at least for marking played or favorite.)
2. Complete actions for the "Item" main menu.
3. Support common shortcuts such as `Cmd+N`, `Cmd+shift+N`, `Cmd+Backspace`, and `Cmd+I`
4. Unifying menu items `Mark as Played` & `Mark as unplayed` into a single one with dynamic title and dash icon.
5. Slightly edited and reordered some menu items to follow best practices. 

* Bulk editing for episode list:
    <img width="507" alt="Screenshot 2022-01-08 16 37 03" src="https://user-images.githubusercontent.com/8158163/148637848-0eecd53f-9547-43b2-9ac5-b9602ee91cf6.png">

* Right-Click editing for single item while multiple items selected:
    <img width="513" alt="Screenshot 2022-01-08 16 36 13" src="https://user-images.githubusercontent.com/8158163/148637884-39a9a069-bf5b-4d37-ac53-9560c761667b.png">

* Bulk actions for podcast list:
    Bulk reloads for multiple podcasts is disabled currently (seems to be a little problematic)
    <img width="478" alt="Screenshot 2022-01-08 16 38 21" src="https://user-images.githubusercontent.com/8158163/148637978-8101e0a0-d4df-47c2-a33c-189c2a4a85d9.png">

* Main menu actions:
    <img width="492" alt="Screenshot 2022-01-08 16 48 03" src="https://user-images.githubusercontent.com/8158163/148638094-fd71da1c-df56-4871-b6c8-2d93a286d839.png">
    <img width="324" alt="Screenshot 2022-01-08 16 47 51" src="https://user-images.githubusercontent.com/8158163/148638096-f53ac8a1-91f1-4c69-bd09-73f8aa198f2b.png">