### PR TITLE
Move PlayerView to the bottom of the main window with a vibrant background

### DIFF
--- a/Doughnut.xcodeproj/project.pbxproj
+++ b/Doughnut.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		6B0605C52788627D00A8A91E /* NSMenu+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0605C42788627D00A8A91E /* NSMenu+Extensions.swift */; };
 		6B94DF4C278968F500BCB149 /* NSTableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B94DF4B278968F500BCB149 /* NSTableView+Extensions.swift */; };
 		6BB5771E278602B400DFF99F /* MainMenu.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6BB5771C278602B400DFF99F /* MainMenu.storyboard */; };
+		6BD0F42F27872EDB0008F881 /* PlayerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BD0F42E27872EDB0008F881 /* PlayerViewController.swift */; };
 		6BF126D12780727100D840A4 /* EpisodeInfo.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6BF126D02780727100D840A4 /* EpisodeInfo.storyboard */; };
 		6BF126D32780742600D840A4 /* PodcastInfo.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6BF126D22780742600D840A4 /* PodcastInfo.storyboard */; };
 		830A33C81FF042C900C13B1D /* Library.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FB4EB71F7BD9A1001CD842 /* Library.swift */; };
@@ -179,6 +180,7 @@
 		6B730B732767A90900FB5F84 /* Doughnut-Release.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Doughnut-Release.entitlements"; sourceTree = "<group>"; };
 		6B94DF4B278968F500BCB149 /* NSTableView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTableView+Extensions.swift"; sourceTree = "<group>"; };
 		6BB5771D278602B400DFF99F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainMenu.storyboard; sourceTree = "<group>"; };
+		6BD0F42E27872EDB0008F881 /* PlayerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewController.swift; sourceTree = "<group>"; };
 		6BF126D02780727100D840A4 /* EpisodeInfo.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = EpisodeInfo.storyboard; sourceTree = "<group>"; };
 		6BF126D22780742600D840A4 /* PodcastInfo.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = PodcastInfo.storyboard; sourceTree = "<group>"; };
 		830A34021FF0447D00C13B1D /* PodcastUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastUITests.swift; sourceTree = "<group>"; };
@@ -407,6 +409,7 @@
 				834342691F802C1400913C0B /* EpisodeFilterViewController.swift */,
 				837D52BD1F8E622200C17514 /* TasksViewController.swift */,
 				83DB16E01F93FB460062B266 /* SubscribeViewController.swift */,
+				6BD0F42E27872EDB0008F881 /* PlayerViewController.swift */,
 			);
 			path = "View Controllers";
 			sourceTree = "<group>";
@@ -841,6 +844,7 @@
 				83A0D4831FFC2FA400A376FD /* TaskQueue.swift in Sources */,
 				83667DF01F76D20C00F1ABC0 /* PodcastViewController.swift in Sources */,
 				83D9710C1F812E910091822A /* PlayerView.swift in Sources */,
+				6BD0F42F27872EDB0008F881 /* PlayerViewController.swift in Sources */,
 				83235C042009473200BC356F /* PrefLibraryViewController.swift in Sources */,
 				6B0605C52788627D00A8A91E /* NSMenu+Extensions.swift in Sources */,
 				839DBDA41FEEE658007610EF /* ShowPodcastWindow.swift in Sources */,

--- a/Doughnut/Base.lproj/Main.storyboard
+++ b/Doughnut/Base.lproj/Main.storyboard
@@ -229,15 +229,6 @@ Gw
                                         <action selector="toggleNewEpisodes:" target="B8D-0N-5wS" id="AqT-s0-Y6z"/>
                                     </connections>
                                 </toolbarItem>
-                                <toolbarItem implicitItemIdentifier="D9AB39C8-3B36-4357-95AC-C446E076C634" label="Custom View" paletteLabel="Player View" tag="-1" id="Psv-5X-LNl">
-                                    <nil key="toolTip"/>
-                                    <size key="minSize" width="465" height="38"/>
-                                    <size key="maxSize" width="465" height="41"/>
-                                    <customView key="view" id="qY3-fM-qgT" customClass="PlayerView" customModule="Doughnut" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="14" width="465" height="38"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    </customView>
-                                </toolbarItem>
                                 <toolbarItem implicitItemIdentifier="9A64A10D-F674-4BDB-B75D-5D7AEF001779" label="" paletteLabel="Download Queue Button" image="DownloadsIcon" id="3ZS-BL-qK1">
                                     <nil key="toolTip"/>
                                     <size key="minSize" width="28" height="25"/>
@@ -292,8 +283,6 @@ Gw
                                 <toolbarItem reference="6L2-aH-OKv"/>
                                 <toolbarItem reference="xhE-FB-d65"/>
                                 <toolbarItem reference="cKK-pR-jXd"/>
-                                <toolbarItem reference="Psv-5X-LNl"/>
-                                <toolbarItem reference="cKK-pR-jXd"/>
                                 <toolbarItem reference="zd4-bJ-Dkk"/>
                                 <toolbarItem reference="9qL-Cl-fVy"/>
                             </defaultToolbarItems>
@@ -306,7 +295,6 @@ Gw
                         <outlet property="allToggle" destination="0x1-F9-vTA" id="5Ik-2C-flf"/>
                         <outlet property="downloadsButton" destination="3ZS-BL-qK1" id="Dx5-9Y-qk9"/>
                         <outlet property="newToggle" destination="lAe-YH-TAR" id="0xd-Ho-EFT"/>
-                        <outlet property="playerView" destination="Psv-5X-LNl" id="WFu-8c-S1d"/>
                         <outlet property="searchInputView" destination="Q3N-wA-1B1" id="JgQ-vM-uE4"/>
                         <segue destination="zrU-nU-rD6" kind="relationship" relationship="window.shadowedContentViewController" id="KFV-RY-whX"/>
                     </connections>
@@ -332,6 +320,7 @@ Gw
                         </connections>
                     </splitView>
                     <connections>
+                        <outlet property="playerViewController" destination="UKb-Ik-lcF" id="7Pf-4A-npC"/>
                         <outlet property="splitView" destination="ucZ-EJ-Szj" id="vKW-Rh-xTc"/>
                         <segue destination="hBf-lZ-L6q" kind="relationship" relationship="splitItems" id="0dw-28-qmw"/>
                         <segue destination="GEj-8A-BQz" kind="relationship" relationship="splitItems" id="mSO-oJ-Inb"/>
@@ -339,6 +328,45 @@ Gw
                     </connections>
                 </splitViewController>
                 <customObject id="aEf-6q-K2I" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+                <customView id="J7h-Vy-J1l">
+                    <rect key="frame" x="0.0" y="0.0" width="465" height="38"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <subviews>
+                        <visualEffectView wantsLayer="YES" blendingMode="withinWindow" material="headerView" state="followsWindowActiveState" translatesAutoresizingMaskIntoConstraints="NO" id="hXb-MT-AcX">
+                            <rect key="frame" x="0.0" y="0.0" width="465" height="38"/>
+                        </visualEffectView>
+                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="78j-yn-uqz" customClass="PlayerView" customModule="Doughnut" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="465" height="38"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="38" id="DSx-Wi-TuU"/>
+                                <constraint firstAttribute="width" constant="465" id="gJz-hR-Ryq"/>
+                            </constraints>
+                        </customView>
+                        <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="NKm-ft-W3Y">
+                            <rect key="frame" x="0.0" y="35" width="465" height="5"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="1" id="aHe-jm-15F"/>
+                            </constraints>
+                        </box>
+                    </subviews>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="NKm-ft-W3Y" secondAttribute="trailing" id="2TT-hL-Na4"/>
+                        <constraint firstItem="78j-yn-uqz" firstAttribute="centerX" secondItem="J7h-Vy-J1l" secondAttribute="centerX" id="4aO-Wz-HaR"/>
+                        <constraint firstAttribute="trailing" secondItem="hXb-MT-AcX" secondAttribute="trailing" id="BBc-TI-pQE"/>
+                        <constraint firstItem="hXb-MT-AcX" firstAttribute="top" secondItem="J7h-Vy-J1l" secondAttribute="top" id="OLv-fj-Noa"/>
+                        <constraint firstItem="78j-yn-uqz" firstAttribute="centerY" secondItem="J7h-Vy-J1l" secondAttribute="centerY" id="Pdo-kB-Q5c"/>
+                        <constraint firstItem="NKm-ft-W3Y" firstAttribute="leading" secondItem="J7h-Vy-J1l" secondAttribute="leading" id="X48-mh-OHI"/>
+                        <constraint firstItem="NKm-ft-W3Y" firstAttribute="top" secondItem="J7h-Vy-J1l" secondAttribute="top" id="hPo-Iz-LW0"/>
+                        <constraint firstAttribute="bottom" secondItem="hXb-MT-AcX" secondAttribute="bottom" id="qIv-XQ-nWQ"/>
+                        <constraint firstItem="hXb-MT-AcX" firstAttribute="leading" secondItem="J7h-Vy-J1l" secondAttribute="leading" id="vQg-8L-uQw"/>
+                    </constraints>
+                </customView>
+                <customObject id="UKb-Ik-lcF" customClass="PlayerViewController" customModule="Doughnut" customModuleProvider="target">
+                    <connections>
+                        <outlet property="playerView" destination="78j-yn-uqz" id="i4E-Om-KC1"/>
+                        <outlet property="view" destination="J7h-Vy-J1l" id="bEp-bC-Fuv"/>
+                    </connections>
+                </customObject>
             </objects>
             <point key="canvasLocation" x="-102.5" y="707"/>
         </scene>

--- a/Doughnut/Base.lproj/Main.storyboard
+++ b/Doughnut/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
-        <plugIn identifier="com.apple.WebKit2IBPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
+        <plugIn identifier="com.apple.WebKit2IBPlugin" version="19529"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -144,11 +144,11 @@ Gw
             <objects>
                 <viewController storyboardIdentifier="TasksPopover" id="j0w-4Y-s9R" customClass="TasksViewController" customModule="Doughnut" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="DKL-cK-blD">
-                        <rect key="frame" x="0.0" y="0.0" width="316" height="83"/>
+                        <rect key="frame" x="0.0" y="0.0" width="316" height="82"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IXl-17-Y4f">
-                                <rect key="frame" x="-2" y="58" width="320" height="17"/>
+                                <rect key="frame" x="-2" y="58" width="320" height="16"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="316" id="5NZ-jj-Pga"/>
                                 </constraints>
@@ -197,7 +197,7 @@ Gw
                             <allowedToolbarItems>
                                 <toolbarItem implicitItemIdentifier="NSToolbarSpaceItem" id="24m-vf-dRH"/>
                                 <toolbarItem implicitItemIdentifier="NSToolbarFlexibleSpaceItem" id="cKK-pR-jXd"/>
-                                <toolbarItem implicitItemIdentifier="F8E7139A-1097-4EC9-9875-0FAB2336FC65" label="Custom View" paletteLabel="Custom View" id="kDe-15-3rO">
+                                <toolbarItem implicitItemIdentifier="F8E7139A-1097-4EC9-9875-0FAB2336FC65" label="Custom View" paletteLabel="Custom View" title="All" id="kDe-15-3rO">
                                     <nil key="toolTip"/>
                                     <size key="minSize" width="40" height="18"/>
                                     <size key="maxSize" width="40" height="25"/>
@@ -213,7 +213,7 @@ Gw
                                         <action selector="toggleAllEpisodes:" target="B8D-0N-5wS" id="gpj-C0-hOS"/>
                                     </connections>
                                 </toolbarItem>
-                                <toolbarItem implicitItemIdentifier="8965E721-3D66-41BE-9EA1-7C449D303C1B" label="Custom View" paletteLabel="Custom View" id="6L2-aH-OKv">
+                                <toolbarItem implicitItemIdentifier="8965E721-3D66-41BE-9EA1-7C449D303C1B" label="Custom View" paletteLabel="Custom View" title="New" id="6L2-aH-OKv">
                                     <nil key="toolTip"/>
                                     <size key="minSize" width="40" height="18"/>
                                     <size key="maxSize" width="40" height="25"/>
@@ -347,25 +347,24 @@ Gw
             <objects>
                 <viewController id="hBf-lZ-L6q" customClass="PodcastViewController" customModule="Doughnut" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="D1G-wk-4ey">
-                        <rect key="frame" x="0.0" y="0.0" width="231" height="421"/>
+                        <rect key="frame" x="0.0" y="0.0" width="251" height="421"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="59" horizontalPageScroll="10" verticalLineScroll="59" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Olf-xm-4xZ">
-                                <rect key="frame" x="0.0" y="0.0" width="231" height="401"/>
+                                <rect key="frame" x="0.0" y="0.0" width="251" height="401"/>
                                 <clipView key="contentView" drawsBackground="NO" id="RU8-8U-i4z">
-                                    <rect key="frame" x="0.0" y="0.0" width="231" height="401"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="251" height="401"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnSelection="YES" columnResizing="NO" autosaveColumns="NO" rowHeight="55" viewBased="YES" id="aVy-1A-ODd">
-                                            <rect key="frame" x="0.0" y="0.0" width="231" height="401"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="251" height="401"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="0.0" height="4"/>
                                             <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn identifier="defaultRow" width="231" minWidth="40" maxWidth="1000" id="JOg-Pd-0OD">
+                                                <tableColumn identifier="defaultRow" width="219" minWidth="40" maxWidth="1000" id="JOg-Pd-0OD">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -377,11 +376,11 @@ Gw
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="Caz-b2-UzS" customClass="PodcastCellView" customModule="Doughnut" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="2" width="231" height="55"/>
+                                                            <rect key="frame" x="10" y="2" width="231" height="55"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yFZ-qJ-tU0">
-                                                                    <rect key="frame" x="59" y="36" width="129" height="17"/>
+                                                                    <rect key="frame" x="59" y="37" width="129" height="16"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Podcast Name" id="zzu-C6-FLg">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -470,7 +469,7 @@ Gw
                                 </scroller>
                             </scrollView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="uiz-QK-vYc" customClass="SortingView" customModule="Doughnut" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="401" width="231" height="20"/>
+                                <rect key="frame" x="0.0" y="401" width="251" height="20"/>
                             </customView>
                         </subviews>
                         <constraints>
@@ -548,24 +547,23 @@ Gw
             <objects>
                 <viewController id="GEj-8A-BQz" customClass="EpisodeViewController" customModule="Doughnut" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="tvM-2C-S0k">
-                        <rect key="frame" x="0.0" y="0.0" width="331" height="420"/>
+                        <rect key="frame" x="0.0" y="0.0" width="351" height="420"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView wantsLayer="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="76" horizontalPageScroll="10" verticalLineScroll="76" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aPG-xC-7JH">
-                                <rect key="frame" x="0.0" y="0.0" width="331" height="400"/>
+                                <rect key="frame" x="0.0" y="0.0" width="351" height="400"/>
                                 <clipView key="contentView" id="Ugp-W0-ujw">
-                                    <rect key="frame" x="0.0" y="0.0" width="331" height="400"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="351" height="400"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" autosaveColumns="NO" rowHeight="76" viewBased="YES" id="Xrx-cp-IWJ">
-                                            <rect key="frame" x="0.0" y="0.0" width="331" height="400"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="351" height="400"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn identifier="defaultRow" width="331" minWidth="40" maxWidth="1000" id="Ijn-kk-ecd">
+                                                <tableColumn identifier="defaultRow" width="319" minWidth="40" maxWidth="1000" id="Ijn-kk-ecd">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -577,7 +575,7 @@ Gw
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="duq-gB-b2g" customClass="EpisodeCellView" customModule="Doughnut" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="0.0" width="331" height="76"/>
+                                                            <rect key="frame" x="10" y="0.0" width="331" height="76"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c7R-O5-skY">
@@ -672,7 +670,7 @@ Gw
                                 </scroller>
                             </scrollView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="z1v-iO-axc" customClass="SortingView" customModule="Doughnut" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="400" width="331" height="20"/>
+                                <rect key="frame" x="0.0" y="400" width="351" height="20"/>
                             </customView>
                         </subviews>
                         <constraints>
@@ -773,14 +771,14 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <wkWebView wantsLayer="YES" verticalHuggingPriority="750" allowsLinkPreview="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ElX-b1-U2Z" customClass="DetailWebView" customModule="Doughnut" customModuleProvider="target">
-                                <rect key="frame" x="20" y="20" width="407" height="376"/>
+                                <rect key="frame" x="20" y="20" width="407" height="377"/>
                                 <wkWebViewConfiguration key="configuration" applicationNameForUserAgent="Doughnut" suppressesIncrementalRendering="YES">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                                     <wkPreferences key="preferences" javaScriptCanOpenWindowsAutomatically="NO" javaScriptEnabled="NO"/>
                                 </wkWebViewConfiguration>
                             </wkWebView>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="jKU-pr-cPD">
-                                <rect key="frame" x="18" y="450" width="333" height="21"/>
+                                <rect key="frame" x="18" y="451" width="333" height="20"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" id="taL-3O-s2s">
                                     <font key="font" metaFont="system" size="17"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -788,7 +786,7 @@ Gw
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ecQ-ID-8dU">
-                                <rect key="frame" x="18" y="428" width="333" height="19"/>
+                                <rect key="frame" x="18" y="429" width="333" height="19"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" id="g3S-AT-eFY">
                                     <font key="font" metaFont="system" size="15"/>
                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -804,7 +802,7 @@ Gw
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="1sE-hb-2L4"/>
                             </imageView>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="dNt-cn-mfd">
-                                <rect key="frame" x="18" y="409" width="333" height="14"/>
+                                <rect key="frame" x="18" y="410" width="333" height="14"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" id="W3b-zq-LTM">
                                     <font key="font" metaFont="smallSystem"/>
                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -845,7 +843,7 @@ Gw
     </scenes>
     <resources>
         <image name="DownloadsIcon" width="18" height="18"/>
-        <image name="NSRefreshTemplate" width="11" height="15"/>
+        <image name="NSRefreshTemplate" width="14" height="16"/>
         <image name="PlaceholderIcon" width="79" height="78.5"/>
     </resources>
 </document>

--- a/Doughnut/View Controllers/EpisodeViewController.swift
+++ b/Doughnut/View Controllers/EpisodeViewController.swift
@@ -82,6 +82,15 @@ class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTableViewD
     sortView.sortDirection = sortDirection
     sortView.delegate = self
 
+    let scrollView = tableView.enclosingScrollView!
+    scrollView.automaticallyAdjustsContentInsets = false
+    scrollView.contentInsets = NSEdgeInsets(
+      top: 0,
+      left: 0,
+      bottom: ViewController.Constants.playerViewHeight,
+      right: 0
+    )
+
     tableView.registerForDraggedTypes([NSPasteboard.PasteboardType("NSFilenamesPboardType")])
   }
 
@@ -209,6 +218,12 @@ class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTableViewD
     }
 
     return true
+  }
+
+  func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+    // Implement -[NSTableViewDelegate tableView:heightOfRow:] to fix an issue
+    // that the bottom inset of NSTableView disappears on macOS Monterey.
+    return tableView.rowHeight
   }
 
   @objc func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {

--- a/Doughnut/View Controllers/PlayerViewController.swift
+++ b/Doughnut/View Controllers/PlayerViewController.swift
@@ -1,0 +1,29 @@
+/*
+ * Doughnut Podcast Client
+ * Copyright (C) 2022 Ethan Wong
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Cocoa
+
+final class PlayerViewController: NSViewController {
+
+  @IBOutlet weak var playerView: PlayerView!
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+  }
+
+}

--- a/Doughnut/View Controllers/ViewController.swift
+++ b/Doughnut/View Controllers/ViewController.swift
@@ -23,7 +23,12 @@ enum GlobalFilter {
   case New
 }
 
-class ViewController: NSSplitViewController, LibraryDelegate {
+final class ViewController: NSSplitViewController, LibraryDelegate {
+
+  struct Constants {
+    static let playerViewHeight: CGFloat = 38
+  }
+
   enum Events: String {
     case PodcastSelected
 
@@ -31,6 +36,8 @@ class ViewController: NSSplitViewController, LibraryDelegate {
       return Notification.Name(rawValue: self.rawValue)
     }
   }
+
+  @IBOutlet var playerViewController: PlayerViewController!
 
   var globalFilter: GlobalFilter = .All
 
@@ -61,6 +68,55 @@ class ViewController: NSSplitViewController, LibraryDelegate {
     splitView.autosaveName = "Main"
 
     Library.global.delegate = self
+
+    setupPlayerView()
+  }
+
+  private func setupPlayerView() {
+    view.addSubview(playerViewController.view)
+    playerViewController.view.translatesAutoresizingMaskIntoConstraints = false
+
+    let secondColumnController = splitViewItems[1].viewController
+    let thirdColumnController = splitViewItems[2].viewController
+
+    view.addConstraints([
+      NSLayoutConstraint(
+        item: playerViewController.view,
+        attribute: .bottom,
+        relatedBy: .equal,
+        toItem: view,
+        attribute: .bottom,
+        multiplier: 1,
+        constant: 0
+      ),
+      NSLayoutConstraint(
+        item: playerViewController.view,
+        attribute: .leading,
+        relatedBy: .equal,
+        toItem: secondColumnController.view,
+        attribute: .leading,
+        multiplier: 1,
+        constant: 0
+      ),
+      NSLayoutConstraint(
+        item: playerViewController.view,
+        attribute: .trailing,
+        relatedBy: .equal,
+        toItem: thirdColumnController.view,
+        attribute: .trailing,
+        multiplier: 1,
+        constant: 0
+      ),
+      NSLayoutConstraint(
+        item: playerViewController.view,
+        attribute: .height,
+        relatedBy: .equal,
+        toItem: nil,
+        attribute: .notAnAttribute,
+        multiplier: 1,
+        constant: Constants.playerViewHeight
+      ),
+    ])
   }
 
   deinit {

--- a/Doughnut/Views/PlayerView.swift
+++ b/Doughnut/Views/PlayerView.swift
@@ -130,60 +130,6 @@ class PlayerView: NSView, PlayerDelegate {
     addSubview(playedRemainingLbl)
  }
 
-  override func draw(_ dirtyRect: NSRect) {
-    let darkMode = DoughnutApp.darkMode()
-
-    if self.window?.isMainWindow ?? false {
-      var bgGradient = NSGradient(starting: NSColor(calibratedRed: 0.945, green: 0.945, blue: 0.945, alpha: 1.0), ending: NSColor(calibratedRed: 0.894, green: 0.894, blue: 0.894, alpha: 1.0))
-
-      NSColor(calibratedRed: 0.784, green: 0.784, blue: 0.784, alpha: 1.0).setStroke()
-
-      if darkMode {
-        bgGradient = NSGradient(starting: NSColor(calibratedRed: 0.170, green: 0.162, blue: 0.158, alpha: 1.00), ending: NSColor(calibratedRed: 0.220, green: 0.212, blue: 0.208, alpha: 1.00))
-
-        NSColor(calibratedRed: 0.180, green: 0.161, blue: 0.161, alpha: 1.0).setStroke()
-      }
-
-      bgGradient?.draw(in: self.bounds, angle: 270)
-
-    } else {
-      var bgGradient = NSGradient(starting: NSColor(calibratedRed: 0.980, green: 0.980, blue: 0.980, alpha: 1.0), ending: NSColor(calibratedRed: 0.980, green: 0.980, blue: 0.980, alpha: 1.0))
-
-      NSColor(calibratedRed: 0.902, green: 0.902, blue: 0.902, alpha: 1.0).setStroke()
-
-      if darkMode {
-        bgGradient = NSGradient(starting: NSColor(calibratedRed: 0.170, green: 0.162, blue: 0.158, alpha: 1.00), ending: NSColor(calibratedRed: 0.220, green: 0.212, blue: 0.208, alpha: 1.00))
-
-        NSColor(calibratedRed: 0.180, green: 0.161, blue: 0.161, alpha: 1.0).setStroke()
-      }
-
-      bgGradient?.draw(in: self.bounds, angle: 270)
-    }
-
-    let leftBorder = NSBezierPath()
-    leftBorder.move(to: NSPoint(x: 0.5, y: 0))
-    leftBorder.line(to: NSPoint(x: 0.5, y: self.bounds.size.height))
-    leftBorder.stroke()
-
-    let rightBorder = NSBezierPath()
-    rightBorder.move(to: NSPoint(x: self.bounds.size.width - 0.5, y: 0))
-    rightBorder.line(to: NSPoint(x: self.bounds.size.width - 0.5, y: self.bounds.size.height))
-    rightBorder.stroke()
-
-    // Draw a solid black line at the bottom to match macOS's dark mode style
-    if darkMode {
-      NSColor.black.setStroke()
-
-      let bottomBorder = NSBezierPath()
-      bottomBorder.move(to: NSPoint(x: 0.5, y: 0))
-      bottomBorder.line(to: NSPoint(x: self.bounds.size.width - 0.5, y: 0))
-      bottomBorder.lineWidth = 1.5
-      bottomBorder.stroke()
-    }
-
-    super.draw(dirtyRect)
-  }
-
   func formatTime(total: Int) -> String {
     let hrs = Int(floor(Double(total / 3600)))
     let mins = Int(floor(Double((total % 3600) / 60)))

--- a/Doughnut/WindowController.swift
+++ b/Doughnut/WindowController.swift
@@ -21,7 +21,6 @@ import Cocoa
 class WindowController: NSWindowController, NSWindowDelegate, NSTextFieldDelegate, DownloadManagerDelegate {
   @IBOutlet var allToggle: NSButton!
   @IBOutlet var newToggle: NSButton!
-  @IBOutlet var playerView: NSToolbarItem!
   @IBOutlet weak var downloadsButton: NSToolbarItem!
   @IBOutlet weak var searchInputView: NSTextField!
 
@@ -143,13 +142,13 @@ class WindowController: NSWindowController, NSWindowDelegate, NSTextFieldDelegat
   }
 
   func windowDidResignKey(_ notification: Notification) {
-    if let player = playerView.view as? PlayerView {
+    if let player = viewController?.playerViewController.playerView {
       player.needsDisplay = true
     }
   }
 
   func windowDidBecomeKey(_ notification: Notification) {
-    if let player = playerView.view as? PlayerView {
+    if let player = viewController?.playerViewController.playerView {
       player.needsDisplay = true
     }
   }


### PR DESCRIPTION
This PR:
1. Moves `PlayerView` to the bottom of the main window, spanning across two columns except for the sidebar.
2. Replaces the gradient gradient with a visual effect view to provide translucency.

Most Mac apps that plays audio, excluding system ones, ships ships with their playback status view on the bottom. Moving `PlayerView` to the bottom frees space from the toolbar, which allows more room for toolbar action buttons and the future adaptation for Big Sur's sectioned toolbar for split view and allow user to toggle the toolbar off.

`PlayerView` lacks responsiveness since it doesn't use Auto Layout. Current implementation wraps the entire view centered into a full-width view controller, preserving its original content, width and height.

<img width="1032" alt="2022-01-10 21 44 40" src="https://user-images.githubusercontent.com/8158163/148776389-88f98998-d17c-4f95-94a5-28f23fa129e9.png">
<img width="1032" alt="2022-01-10 21 46 47" src="https://user-images.githubusercontent.com/8158163/148776398-e23973a6-f4e4-4a70-9e6a-32520e6768fd.png">
