### PR TITLE
Update sidebar and toolbar appearance for modern macOS

### DIFF
--- a/Doughnut.xcodeproj/project.pbxproj
+++ b/Doughnut.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		2AB07BF789841271ED80EA26 /* Pods_DoughnutUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25D4796441E8F7922FCDAF9A /* Pods_DoughnutUITests.framework */; };
 		4125A143137AD05319B3DEFC /* Pods_Doughnut.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2661E19A57B17099FC4ECCDD /* Pods_Doughnut.framework */; };
 		6B0605C52788627D00A8A91E /* NSMenu+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0605C42788627D00A8A91E /* NSMenu+Extensions.swift */; };
+		6B3A75F8278F44F500F25578 /* NSView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3A75F7278F44F500F25578 /* NSView+Extensions.swift */; };
 		6B94DF4C278968F500BCB149 /* NSTableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B94DF4B278968F500BCB149 /* NSTableView+Extensions.swift */; };
 		6BB5771E278602B400DFF99F /* MainMenu.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6BB5771C278602B400DFF99F /* MainMenu.storyboard */; };
 		6BF126D12780727100D840A4 /* EpisodeInfo.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6BF126D02780727100D840A4 /* EpisodeInfo.storyboard */; };
@@ -175,6 +176,7 @@
 		558EE5E875BAF91152803575 /* Pods_DoughnutTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DoughnutTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E1DC050EEE121FD033C44DF /* Pods-Doughnut.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Doughnut.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Doughnut/Pods-Doughnut.debug.xcconfig"; sourceTree = "<group>"; };
 		6B0605C42788627D00A8A91E /* NSMenu+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMenu+Extensions.swift"; sourceTree = "<group>"; };
+		6B3A75F7278F44F500F25578 /* NSView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSView+Extensions.swift"; sourceTree = "<group>"; };
 		6B3ACC982773555700CF1EF1 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		6B730B732767A90900FB5F84 /* Doughnut-Release.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Doughnut-Release.entitlements"; sourceTree = "<group>"; };
 		6B94DF4B278968F500BCB149 /* NSTableView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTableView+Extensions.swift"; sourceTree = "<group>"; };
@@ -305,6 +307,7 @@
 			children = (
 				6B0605C42788627D00A8A91E /* NSMenu+Extensions.swift */,
 				6B94DF4B278968F500BCB149 /* NSTableView+Extensions.swift */,
+				6B3A75F7278F44F500F25578 /* NSView+Extensions.swift */,
 			);
 			name = AppKit;
 			sourceTree = "<group>";
@@ -855,6 +858,7 @@
 				830B159B1F7B97910086C121 /* PodcastCellView.swift in Sources */,
 				83235C072009473500BC356F /* PrefPlaybackViewController.swift in Sources */,
 				830E99BD1FF50DD000B728BE /* ActivityIndicator.swift in Sources */,
+				6B3A75F8278F44F500F25578 /* NSView+Extensions.swift in Sources */,
 				839DBDA71FEEEA81007610EF /* WhiteBackgroundView.swift in Sources */,
 				838257D01F759F6F00DB4FD1 /* ViewController.swift in Sources */,
 				83659AB81F7D8A0300E09833 /* Podcast.swift in Sources */,

--- a/Doughnut/Base.lproj/Main.storyboard
+++ b/Doughnut/Base.lproj/Main.storyboard
@@ -230,13 +230,11 @@ Gw
                                         <action selector="toggleNewEpisodes:" target="B8D-0N-5wS" id="AqT-s0-Y6z"/>
                                     </connections>
                                 </toolbarItem>
-                                <toolbarItem implicitItemIdentifier="D9AB39C8-3B36-4357-95AC-C446E076C634" label="Custom View" paletteLabel="Player View" tag="-1" id="Psv-5X-LNl">
+                                <toolbarItem implicitItemIdentifier="D9AB39C8-3B36-4357-95AC-C446E076C634" label="Playback" paletteLabel="Player View" tag="-1" visibilityPriority="1001" sizingBehavior="auto" id="Psv-5X-LNl">
                                     <nil key="toolTip"/>
-                                    <size key="minSize" width="465" height="38"/>
-                                    <size key="maxSize" width="465" height="41"/>
                                     <customView key="view" id="qY3-fM-qgT" customClass="PlayerView" customModule="Doughnut" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="14" width="465" height="38"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                        <rect key="frame" x="0.0" y="14" width="465" height="32"/>
+                                        <autoresizingMask key="autoresizingMask"/>
                                     </customView>
                                 </toolbarItem>
                                 <toolbarItem implicitItemIdentifier="9A64A10D-F674-4BDB-B75D-5D7AEF001779" label="" paletteLabel="Download Queue Button" image="DownloadsIcon" id="3ZS-BL-qK1">
@@ -255,20 +253,6 @@ Gw
                                         </connections>
                                     </button>
                                 </toolbarItem>
-                                <toolbarItem implicitItemIdentifier="824C3448-3C44-4816-BEC9-E61A2DE9BD00" label="Search" paletteLabel="Search" id="9qL-Cl-fVy">
-                                    <nil key="toolTip"/>
-                                    <size key="minSize" width="124" height="22"/>
-                                    <size key="maxSize" width="124" height="22"/>
-                                    <textField key="view" verticalHuggingPriority="750" id="Q3N-wA-1B1">
-                                        <rect key="frame" x="0.0" y="14" width="124" height="22"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="center" placeholderString="Search..." drawsBackground="YES" id="ngp-Ov-F6y">
-                                            <font key="font" metaFont="system"/>
-                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                        </textFieldCell>
-                                    </textField>
-                                </toolbarItem>
                                 <toolbarItem implicitItemIdentifier="0446AA35-D828-4B36-B4C9-23B4D2BF0006" label="Task Manager" paletteLabel="Task Manager" tag="-1" id="zd4-bJ-Dkk">
                                     <nil key="toolTip"/>
                                     <size key="minSize" width="32" height="38"/>
@@ -278,25 +262,26 @@ Gw
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                     </customView>
                                 </toolbarItem>
-                                <toolbarItem implicitItemIdentifier="4D92DF7E-3C1E-417A-979F-6131A608B925" label="Offset Spacer" paletteLabel="Offset Spacer" tag="-1" id="xhE-FB-d65">
+                                <toolbarItem implicitItemIdentifier="30738650-C932-4F7A-90D7-03F06658D853" label="Search" paletteLabel="Search" visibilityPriority="1000" sizingBehavior="auto" id="mto-Rc-MWj">
                                     <nil key="toolTip"/>
-                                    <size key="minSize" width="60" height="38"/>
-                                    <size key="maxSize" width="60" height="38"/>
-                                    <customView key="view" id="XjW-RQ-MVw">
-                                        <rect key="frame" x="10" y="14" width="60" height="38"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                    </customView>
+                                    <searchField key="view" wantsLayer="YES" verticalHuggingPriority="750" id="zQC-lo-HKP">
+                                        <rect key="frame" x="0.0" y="14" width="96" height="22"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" usesSingleLineMode="YES" bezelStyle="round" id="4eX-Wf-kbB">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </searchFieldCell>
+                                    </searchField>
                                 </toolbarItem>
                             </allowedToolbarItems>
                             <defaultToolbarItems>
                                 <toolbarItem reference="kDe-15-3rO"/>
                                 <toolbarItem reference="6L2-aH-OKv"/>
-                                <toolbarItem reference="xhE-FB-d65"/>
-                                <toolbarItem reference="cKK-pR-jXd"/>
                                 <toolbarItem reference="Psv-5X-LNl"/>
                                 <toolbarItem reference="cKK-pR-jXd"/>
                                 <toolbarItem reference="zd4-bJ-Dkk"/>
-                                <toolbarItem reference="9qL-Cl-fVy"/>
+                                <toolbarItem reference="mto-Rc-MWj"/>
                             </defaultToolbarItems>
                         </toolbar>
                         <connections>
@@ -308,7 +293,7 @@ Gw
                         <outlet property="downloadsButton" destination="3ZS-BL-qK1" id="Dx5-9Y-qk9"/>
                         <outlet property="newToggle" destination="lAe-YH-TAR" id="0xd-Ho-EFT"/>
                         <outlet property="playerView" destination="Psv-5X-LNl" id="WFu-8c-S1d"/>
-                        <outlet property="searchInputView" destination="Q3N-wA-1B1" id="JgQ-vM-uE4"/>
+                        <outlet property="searchInputView" destination="zQC-lo-HKP" id="Hrm-SR-1bt"/>
                         <segue destination="zrU-nU-rD6" kind="relationship" relationship="window.shadowedContentViewController" id="KFV-RY-whX"/>
                     </connections>
                 </windowController>

--- a/Doughnut/Base.lproj/Main.storyboard
+++ b/Doughnut/Base.lproj/Main.storyboard
@@ -4,6 +4,7 @@
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
         <plugIn identifier="com.apple.WebKit2IBPlugin" version="19529"/>
+        <capability name="NSView safe area layout guides" minToolsVersion="12.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -188,7 +189,7 @@ Gw
             <objects>
                 <windowController id="B8D-0N-5wS" customClass="WindowController" customModule="Doughnut" customModuleProvider="target" sceneMemberID="viewController">
                     <window key="window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
-                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="-68" y="240" width="920" height="469"/>
                         <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1027"/>
@@ -320,9 +321,9 @@ Gw
             <objects>
                 <splitViewController id="zrU-nU-rD6" customClass="ViewController" customModule="Doughnut" customModuleProvider="target" sceneMemberID="viewController">
                     <splitViewItems>
-                        <splitViewItem holdingPriority="302" id="oXX-Sj-7dq"/>
-                        <splitViewItem holdingPriority="301" id="nb9-D8-jfe"/>
-                        <splitViewItem holdingPriority="300" id="tHE-Qa-Nnj"/>
+                        <splitViewItem canCollapse="YES" holdingPriority="260" behavior="sidebar" id="oXX-Sj-7dq"/>
+                        <splitViewItem holdingPriority="255" behavior="contentList" id="nb9-D8-jfe"/>
+                        <splitViewItem separatorStyle="none" id="tHE-Qa-Nnj"/>
                     </splitViewItems>
                     <splitView key="splitView" wantsLayer="YES" dividerStyle="thin" vertical="YES" id="ucZ-EJ-Szj">
                         <rect key="frame" x="-401" y="0.0" width="851" height="440"/>
@@ -347,11 +348,17 @@ Gw
             <objects>
                 <viewController id="hBf-lZ-L6q" customClass="PodcastViewController" customModule="Doughnut" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="D1G-wk-4ey">
-                        <rect key="frame" x="0.0" y="0.0" width="251" height="421"/>
+                        <rect key="frame" x="0.0" y="0.0" width="251" height="473"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="uiz-QK-vYc" customClass="SortingView" customModule="Doughnut" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="251" height="20"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="20" id="z3j-li-cq1"/>
+                                </constraints>
+                            </customView>
                             <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="59" horizontalPageScroll="10" verticalLineScroll="59" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Olf-xm-4xZ">
-                                <rect key="frame" x="0.0" y="0.0" width="251" height="401"/>
+                                <rect key="frame" x="0.0" y="20" width="251" height="401"/>
                                 <clipView key="contentView" drawsBackground="NO" id="RU8-8U-i4z">
                                     <rect key="frame" x="0.0" y="0.0" width="251" height="401"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -460,7 +467,7 @@ Gw
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="8o2-oW-nrC"/>
                                 </constraints>
                                 <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="EBJ-uF-a0C">
-                                    <rect key="frame" x="0.0" y="405" width="231" height="16"/>
+                                    <rect key="frame" x="0.0" y="385" width="251" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="NbR-v7-KQZ">
@@ -468,20 +475,18 @@ Gw
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>
-                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="uiz-QK-vYc" customClass="SortingView" customModule="Doughnut" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="401" width="251" height="20"/>
-                            </customView>
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="Olf-xm-4xZ" secondAttribute="trailing" id="3ph-zn-ewk"/>
-                            <constraint firstItem="uiz-QK-vYc" firstAttribute="leading" secondItem="Olf-xm-4xZ" secondAttribute="leading" id="4Xx-IH-9vm"/>
-                            <constraint firstItem="Olf-xm-4xZ" firstAttribute="top" secondItem="D1G-wk-4ey" secondAttribute="top" constant="20" id="ApF-0S-5Yv"/>
-                            <constraint firstItem="uiz-QK-vYc" firstAttribute="top" secondItem="D1G-wk-4ey" secondAttribute="top" id="C2b-u6-3jb"/>
-                            <constraint firstItem="Olf-xm-4xZ" firstAttribute="top" secondItem="uiz-QK-vYc" secondAttribute="bottom" id="O90-Va-Qik"/>
-                            <constraint firstAttribute="bottom" secondItem="Olf-xm-4xZ" secondAttribute="bottom" id="PGc-Iv-hD3"/>
+                            <constraint firstItem="Olf-xm-4xZ" firstAttribute="top" secondItem="SAO-5G-yqV" secondAttribute="top" placeholder="YES" id="5qX-bt-0Cr"/>
+                            <constraint firstItem="uiz-QK-vYc" firstAttribute="trailing" secondItem="D1G-wk-4ey" secondAttribute="trailing" id="EFm-7w-XcJ"/>
+                            <constraint firstItem="uiz-QK-vYc" firstAttribute="leading" secondItem="D1G-wk-4ey" secondAttribute="leading" id="Oog-nu-vzD"/>
+                            <constraint firstAttribute="bottom" secondItem="uiz-QK-vYc" secondAttribute="bottom" id="RQV-co-8ZZ"/>
                             <constraint firstItem="Olf-xm-4xZ" firstAttribute="leading" secondItem="D1G-wk-4ey" secondAttribute="leading" id="bIB-df-ua9"/>
-                            <constraint firstItem="uiz-QK-vYc" firstAttribute="trailing" secondItem="Olf-xm-4xZ" secondAttribute="trailing" id="z2l-iK-QWY"/>
+                            <constraint firstItem="uiz-QK-vYc" firstAttribute="top" secondItem="Olf-xm-4xZ" secondAttribute="bottom" id="qcP-4v-Rlh"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="SAO-5G-yqV"/>
+                        <viewLayoutGuide key="layoutMargins" id="8eP-ga-5Bq"/>
                     </view>
                     <connections>
                         <outlet property="sortView" destination="uiz-QK-vYc" id="2M8-u2-XLD"/>
@@ -547,7 +552,7 @@ Gw
             <objects>
                 <viewController id="GEj-8A-BQz" customClass="EpisodeViewController" customModule="Doughnut" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="tvM-2C-S0k">
-                        <rect key="frame" x="0.0" y="0.0" width="351" height="420"/>
+                        <rect key="frame" x="0.0" y="0.0" width="351" height="472"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView wantsLayer="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="76" horizontalPageScroll="10" verticalLineScroll="76" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aPG-xC-7JH">
@@ -671,18 +676,22 @@ Gw
                             </scrollView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="z1v-iO-axc" customClass="SortingView" customModule="Doughnut" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="400" width="351" height="20"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="20" id="w7A-wS-W8s"/>
+                                </constraints>
                             </customView>
                         </subviews>
                         <constraints>
                             <constraint firstItem="aPG-xC-7JH" firstAttribute="top" secondItem="z1v-iO-axc" secondAttribute="bottom" id="8Uf-Pp-sWy"/>
-                            <constraint firstItem="aPG-xC-7JH" firstAttribute="top" secondItem="tvM-2C-S0k" secondAttribute="top" constant="20" id="BOf-XX-ZDk"/>
+                            <constraint firstItem="aPG-xC-7JH" firstAttribute="bottom" secondItem="tvM-2C-S0k" secondAttribute="bottom" id="8rV-0B-9Kf"/>
                             <constraint firstItem="aPG-xC-7JH" firstAttribute="leading" secondItem="tvM-2C-S0k" secondAttribute="leading" id="JQ4-Mw-4cj"/>
-                            <constraint firstItem="z1v-iO-axc" firstAttribute="top" secondItem="tvM-2C-S0k" secondAttribute="top" id="MtI-IF-uFJ"/>
+                            <constraint firstItem="z1v-iO-axc" firstAttribute="top" secondItem="LFb-tW-kyd" secondAttribute="top" placeholder="YES" id="MtI-IF-uFJ"/>
                             <constraint firstAttribute="trailing" secondItem="aPG-xC-7JH" secondAttribute="trailing" id="fC9-7r-iSI"/>
-                            <constraint firstAttribute="bottom" secondItem="aPG-xC-7JH" secondAttribute="bottom" id="kEV-Ns-r9e"/>
-                            <constraint firstItem="z1v-iO-axc" firstAttribute="leading" secondItem="aPG-xC-7JH" secondAttribute="leading" id="n3u-2w-oae"/>
-                            <constraint firstItem="z1v-iO-axc" firstAttribute="trailing" secondItem="aPG-xC-7JH" secondAttribute="trailing" id="yMl-jS-4fm"/>
+                            <constraint firstItem="z1v-iO-axc" firstAttribute="leading" secondItem="tvM-2C-S0k" secondAttribute="leading" id="mVk-iw-gBD"/>
+                            <constraint firstItem="z1v-iO-axc" firstAttribute="trailing" secondItem="tvM-2C-S0k" secondAttribute="trailing" id="wNa-cc-brd"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="LFb-tW-kyd"/>
+                        <viewLayoutGuide key="layoutMargins" id="fgU-SA-hc5"/>
                     </view>
                     <connections>
                         <outlet property="sortView" destination="z1v-iO-axc" id="qCw-4z-ayn"/>
@@ -761,66 +770,89 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <wkWebView wantsLayer="YES" verticalHuggingPriority="750" allowsLinkPreview="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ElX-b1-U2Z" customClass="DetailWebView" customModule="Doughnut" customModuleProvider="target">
-                                <rect key="frame" x="20" y="20" width="407" height="377"/>
+                                <rect key="frame" x="20" y="20" width="407" height="317"/>
                                 <wkWebViewConfiguration key="configuration" applicationNameForUserAgent="Doughnut" suppressesIncrementalRendering="YES">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                                     <wkPreferences key="preferences" javaScriptCanOpenWindowsAutomatically="NO" javaScriptEnabled="NO"/>
                                 </wkWebViewConfiguration>
                             </wkWebView>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="jKU-pr-cPD">
-                                <rect key="frame" x="18" y="451" width="333" height="20"/>
-                                <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" id="taL-3O-s2s">
-                                    <font key="font" metaFont="system" size="17"/>
-                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ecQ-ID-8dU">
-                                <rect key="frame" x="18" y="429" width="333" height="19"/>
-                                <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" id="g3S-AT-eFY">
-                                    <font key="font" metaFont="system" size="15"/>
-                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
-                            <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iMb-rx-aJo">
-                                <rect key="frame" x="357" y="406" width="70" height="70"/>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="vM9-K9-FQW">
+                                <rect key="frame" x="20" y="353" width="407" height="70"/>
+                                <subviews>
+                                    <stackView distribution="equalSpacing" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fr6-xn-Y13">
+                                        <rect key="frame" x="0.0" y="9" width="337" height="61"/>
+                                        <subviews>
+                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="jKU-pr-cPD">
+                                                <rect key="frame" x="-2" y="41" width="114" height="20"/>
+                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" title="Episode Name" id="taL-3O-s2s">
+                                                    <font key="font" metaFont="system" size="17"/>
+                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ecQ-ID-8dU">
+                                                <rect key="frame" x="-2" y="18" width="104" height="19"/>
+                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" title="Podcast Name" id="g3S-AT-eFY">
+                                                    <font key="font" metaFont="system" size="15"/>
+                                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="dNt-cn-mfd">
+                                                <rect key="frame" x="-2" y="0.0" width="71" height="14"/>
+                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" title="Publish Date" id="W3b-zq-LTM">
+                                                    <font key="font" metaFont="smallSystem"/>
+                                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                        </subviews>
+                                        <visibilityPriorities>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                        </visibilityPriorities>
+                                        <customSpacing>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                        </customSpacing>
+                                    </stackView>
+                                    <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="iMb-rx-aJo">
+                                        <rect key="frame" x="337" y="0.0" width="70" height="70"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="70" id="QG7-6M-jnW"/>
+                                            <constraint firstAttribute="height" constant="70" id="dNG-ha-trn"/>
+                                        </constraints>
+                                        <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="1sE-hb-2L4"/>
+                                    </imageView>
+                                </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="70" id="QG7-6M-jnW"/>
-                                    <constraint firstAttribute="height" constant="70" id="dNG-ha-trn"/>
+                                    <constraint firstItem="Fr6-xn-Y13" firstAttribute="leading" secondItem="vM9-K9-FQW" secondAttribute="leading" id="Ct5-RD-p1Q"/>
+                                    <constraint firstAttribute="trailing" secondItem="iMb-rx-aJo" secondAttribute="trailing" id="Mlf-wg-e4C"/>
+                                    <constraint firstItem="iMb-rx-aJo" firstAttribute="top" secondItem="vM9-K9-FQW" secondAttribute="top" id="cmd-bW-V8E"/>
+                                    <constraint firstAttribute="bottom" secondItem="iMb-rx-aJo" secondAttribute="bottom" id="iZA-cn-j6C"/>
+                                    <constraint firstItem="iMb-rx-aJo" firstAttribute="leading" secondItem="Fr6-xn-Y13" secondAttribute="trailing" id="o5r-Kf-62j"/>
+                                    <constraint firstItem="Fr6-xn-Y13" firstAttribute="top" secondItem="vM9-K9-FQW" secondAttribute="top" id="qR5-vH-IEf"/>
                                 </constraints>
-                                <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="1sE-hb-2L4"/>
-                            </imageView>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="dNt-cn-mfd">
-                                <rect key="frame" x="18" y="410" width="333" height="14"/>
-                                <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" id="W3b-zq-LTM">
-                                    <font key="font" metaFont="smallSystem"/>
-                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
+                            </customView>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="dNt-cn-mfd" firstAttribute="leading" secondItem="ecQ-ID-8dU" secondAttribute="leading" id="0Ms-Ky-Vkm"/>
-                            <constraint firstItem="jKU-pr-cPD" firstAttribute="leading" secondItem="vAG-6Q-UGH" secondAttribute="leading" constant="20" symbolic="YES" id="2sR-0V-LIm"/>
-                            <constraint firstItem="iMb-rx-aJo" firstAttribute="leading" secondItem="dNt-cn-mfd" secondAttribute="trailing" constant="8" symbolic="YES" id="3EM-KO-rbv"/>
-                            <constraint firstItem="dNt-cn-mfd" firstAttribute="top" secondItem="ecQ-ID-8dU" secondAttribute="bottom" constant="5" id="47p-nh-XMj"/>
-                            <constraint firstItem="dNt-cn-mfd" firstAttribute="leading" secondItem="ElX-b1-U2Z" secondAttribute="leading" id="53b-Hq-55x"/>
-                            <constraint firstItem="ElX-b1-U2Z" firstAttribute="trailing" secondItem="iMb-rx-aJo" secondAttribute="trailing" id="BoZ-Xy-vaL"/>
-                            <constraint firstItem="ecQ-ID-8dU" firstAttribute="top" secondItem="jKU-pr-cPD" secondAttribute="bottom" constant="3" id="FTU-pU-cS5"/>
-                            <constraint firstAttribute="bottom" secondItem="ElX-b1-U2Z" secondAttribute="bottom" constant="20" symbolic="YES" id="HTP-AM-pQO"/>
-                            <constraint firstItem="ecQ-ID-8dU" firstAttribute="leading" secondItem="jKU-pr-cPD" secondAttribute="leading" id="NDl-hP-kL2"/>
-                            <constraint firstItem="iMb-rx-aJo" firstAttribute="leading" secondItem="jKU-pr-cPD" secondAttribute="trailing" constant="8" symbolic="YES" id="bOE-5K-B3v"/>
-                            <constraint firstItem="iMb-rx-aJo" firstAttribute="leading" secondItem="ecQ-ID-8dU" secondAttribute="trailing" constant="8" symbolic="YES" id="eGK-xA-ceY"/>
-                            <constraint firstItem="ElX-b1-U2Z" firstAttribute="top" secondItem="dNt-cn-mfd" secondAttribute="bottom" constant="13" id="fiZ-Vi-r4g"/>
-                            <constraint firstAttribute="trailing" secondItem="iMb-rx-aJo" secondAttribute="trailing" constant="20" id="gX3-B5-z5f"/>
-                            <constraint firstItem="iMb-rx-aJo" firstAttribute="top" secondItem="vAG-6Q-UGH" secondAttribute="top" constant="15" id="jD3-II-jUw"/>
-                            <constraint firstItem="jKU-pr-cPD" firstAttribute="top" secondItem="vAG-6Q-UGH" secondAttribute="top" constant="20" symbolic="YES" id="sBM-wM-hr4"/>
+                            <constraint firstAttribute="trailing" secondItem="ElX-b1-U2Z" secondAttribute="trailing" constant="20" id="0Ag-DA-wYD"/>
+                            <constraint firstItem="vM9-K9-FQW" firstAttribute="leading" secondItem="vAG-6Q-UGH" secondAttribute="leading" constant="20" id="Gyp-Uc-Ret"/>
+                            <constraint firstAttribute="bottom" secondItem="ElX-b1-U2Z" secondAttribute="bottom" constant="20" id="HTP-AM-pQO"/>
+                            <constraint firstAttribute="trailing" secondItem="vM9-K9-FQW" secondAttribute="trailing" constant="20" id="IOa-RW-gWX"/>
+                            <constraint firstItem="vM9-K9-FQW" firstAttribute="top" secondItem="Mwf-BJ-1vu" secondAttribute="top" constant="16" placeholder="YES" id="Kji-tG-dJ7"/>
+                            <constraint firstItem="ElX-b1-U2Z" firstAttribute="top" secondItem="vM9-K9-FQW" secondAttribute="bottom" constant="16" id="LAy-6d-87i"/>
+                            <constraint firstItem="ElX-b1-U2Z" firstAttribute="leading" secondItem="vAG-6Q-UGH" secondAttribute="leading" constant="20" id="ooZ-G1-JUu"/>
                         </constraints>
+                        <viewLayoutGuide key="safeArea" id="Mwf-BJ-1vu"/>
+                        <viewLayoutGuide key="layoutMargins" id="fsL-5L-5se"/>
                     </view>
                     <connections>
                         <outlet property="coverImage" destination="iMb-rx-aJo" id="1UO-yl-4O1"/>
                         <outlet property="detailTitle" destination="jKU-pr-cPD" id="ccI-4w-iJf"/>
+                        <outlet property="headerView" destination="vM9-K9-FQW" id="goQ-o8-LJH"/>
                         <outlet property="miniTitle" destination="dNt-cn-mfd" id="HNn-WX-WiQ"/>
                         <outlet property="secondaryTitle" destination="ecQ-ID-8dU" id="bE3-CX-yAN"/>
                         <outlet property="webView" destination="ElX-b1-U2Z" id="r12-Ju-fkp"/>

--- a/Doughnut/Base.lproj/Main.storyboard
+++ b/Doughnut/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="B8D-0N-5wS">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14490.70"/>
-        <plugIn identifier="com.apple.WebKit2IBPlugin" version="14490.70"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
+        <plugIn identifier="com.apple.WebKit2IBPlugin" version="19529"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -144,11 +144,11 @@ Gw
             <objects>
                 <viewController storyboardIdentifier="TasksPopover" id="j0w-4Y-s9R" customClass="TasksViewController" customModule="Doughnut" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="DKL-cK-blD">
-                        <rect key="frame" x="0.0" y="0.0" width="316" height="83"/>
+                        <rect key="frame" x="0.0" y="0.0" width="316" height="82"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IXl-17-Y4f">
-                                <rect key="frame" x="-2" y="58" width="320" height="17"/>
+                                <rect key="frame" x="-2" y="58" width="320" height="16"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="316" id="5NZ-jj-Pga"/>
                                 </constraints>
@@ -197,7 +197,7 @@ Gw
                             <allowedToolbarItems>
                                 <toolbarItem implicitItemIdentifier="NSToolbarSpaceItem" id="24m-vf-dRH"/>
                                 <toolbarItem implicitItemIdentifier="NSToolbarFlexibleSpaceItem" id="cKK-pR-jXd"/>
-                                <toolbarItem implicitItemIdentifier="F8E7139A-1097-4EC9-9875-0FAB2336FC65" label="Custom View" paletteLabel="Custom View" id="kDe-15-3rO">
+                                <toolbarItem implicitItemIdentifier="F8E7139A-1097-4EC9-9875-0FAB2336FC65" label="Custom View" paletteLabel="Custom View" title="All" id="kDe-15-3rO">
                                     <nil key="toolTip"/>
                                     <size key="minSize" width="40" height="18"/>
                                     <size key="maxSize" width="40" height="25"/>
@@ -213,7 +213,7 @@ Gw
                                         <action selector="toggleAllEpisodes:" target="B8D-0N-5wS" id="gpj-C0-hOS"/>
                                     </connections>
                                 </toolbarItem>
-                                <toolbarItem implicitItemIdentifier="8965E721-3D66-41BE-9EA1-7C449D303C1B" label="Custom View" paletteLabel="Custom View" id="6L2-aH-OKv">
+                                <toolbarItem implicitItemIdentifier="8965E721-3D66-41BE-9EA1-7C449D303C1B" label="Custom View" paletteLabel="Custom View" title="New" id="6L2-aH-OKv">
                                     <nil key="toolTip"/>
                                     <size key="minSize" width="40" height="18"/>
                                     <size key="maxSize" width="40" height="25"/>
@@ -347,25 +347,24 @@ Gw
             <objects>
                 <viewController id="hBf-lZ-L6q" customClass="PodcastViewController" customModule="Doughnut" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="D1G-wk-4ey">
-                        <rect key="frame" x="0.0" y="0.0" width="231" height="421"/>
+                        <rect key="frame" x="0.0" y="0.0" width="251" height="421"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="59" horizontalPageScroll="10" verticalLineScroll="59" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Olf-xm-4xZ">
-                                <rect key="frame" x="0.0" y="0.0" width="231" height="401"/>
+                                <rect key="frame" x="0.0" y="0.0" width="251" height="401"/>
                                 <clipView key="contentView" drawsBackground="NO" id="RU8-8U-i4z">
-                                    <rect key="frame" x="0.0" y="0.0" width="231" height="401"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="251" height="401"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnSelection="YES" columnResizing="NO" autosaveColumns="NO" rowHeight="55" viewBased="YES" id="aVy-1A-ODd">
-                                            <rect key="frame" x="0.0" y="0.0" width="231" height="401"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="251" height="401"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="0.0" height="4"/>
                                             <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn identifier="defaultRow" width="231" minWidth="40" maxWidth="1000" id="JOg-Pd-0OD">
+                                                <tableColumn identifier="defaultRow" width="219" minWidth="40" maxWidth="1000" id="JOg-Pd-0OD">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -377,11 +376,11 @@ Gw
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="Caz-b2-UzS" customClass="PodcastCellView" customModule="Doughnut" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="2" width="231" height="55"/>
+                                                            <rect key="frame" x="10" y="2" width="231" height="55"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yFZ-qJ-tU0">
-                                                                    <rect key="frame" x="59" y="36" width="129" height="17"/>
+                                                                    <rect key="frame" x="59" y="37" width="129" height="16"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Podcast Name" id="zzu-C6-FLg">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -470,7 +469,7 @@ Gw
                                 </scroller>
                             </scrollView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="uiz-QK-vYc" customClass="SortingView" customModule="Doughnut" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="401" width="231" height="20"/>
+                                <rect key="frame" x="0.0" y="401" width="251" height="20"/>
                             </customView>
                         </subviews>
                         <constraints>
@@ -548,24 +547,23 @@ Gw
             <objects>
                 <viewController id="GEj-8A-BQz" customClass="EpisodeViewController" customModule="Doughnut" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="tvM-2C-S0k">
-                        <rect key="frame" x="0.0" y="0.0" width="331" height="420"/>
+                        <rect key="frame" x="0.0" y="0.0" width="351" height="420"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <scrollView wantsLayer="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="76" horizontalPageScroll="10" verticalLineScroll="76" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aPG-xC-7JH">
-                                <rect key="frame" x="0.0" y="0.0" width="331" height="400"/>
+                                <rect key="frame" x="0.0" y="0.0" width="351" height="400"/>
                                 <clipView key="contentView" id="Ugp-W0-ujw">
-                                    <rect key="frame" x="0.0" y="0.0" width="331" height="400"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="351" height="400"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" autosaveColumns="NO" rowHeight="76" viewBased="YES" id="Xrx-cp-IWJ">
-                                            <rect key="frame" x="0.0" y="0.0" width="331" height="400"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="351" height="400"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn identifier="defaultRow" width="331" minWidth="40" maxWidth="1000" id="Ijn-kk-ecd">
+                                                <tableColumn identifier="defaultRow" width="319" minWidth="40" maxWidth="1000" id="Ijn-kk-ecd">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                        <font key="font" metaFont="smallSystem"/>
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                     </tableHeaderCell>
@@ -577,7 +575,7 @@ Gw
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="duq-gB-b2g" customClass="EpisodeCellView" customModule="Doughnut" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="0.0" width="331" height="76"/>
+                                                            <rect key="frame" x="10" y="0.0" width="331" height="76"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c7R-O5-skY">
@@ -672,7 +670,7 @@ Gw
                                 </scroller>
                             </scrollView>
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="z1v-iO-axc" customClass="SortingView" customModule="Doughnut" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="400" width="331" height="20"/>
+                                <rect key="frame" x="0.0" y="400" width="351" height="20"/>
                             </customView>
                         </subviews>
                         <constraints>
@@ -763,14 +761,14 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <wkWebView wantsLayer="YES" verticalHuggingPriority="750" allowsLinkPreview="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ElX-b1-U2Z" customClass="DetailWebView" customModule="Doughnut" customModuleProvider="target">
-                                <rect key="frame" x="20" y="20" width="407" height="376"/>
+                                <rect key="frame" x="20" y="20" width="407" height="377"/>
                                 <wkWebViewConfiguration key="configuration" applicationNameForUserAgent="Doughnut" suppressesIncrementalRendering="YES">
                                     <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
                                     <wkPreferences key="preferences" javaScriptCanOpenWindowsAutomatically="NO" javaScriptEnabled="NO"/>
                                 </wkWebViewConfiguration>
                             </wkWebView>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="jKU-pr-cPD">
-                                <rect key="frame" x="18" y="450" width="333" height="21"/>
+                                <rect key="frame" x="18" y="451" width="333" height="20"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" id="taL-3O-s2s">
                                     <font key="font" metaFont="system" size="17"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -778,7 +776,7 @@ Gw
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ecQ-ID-8dU">
-                                <rect key="frame" x="18" y="428" width="333" height="19"/>
+                                <rect key="frame" x="18" y="429" width="333" height="19"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" id="g3S-AT-eFY">
                                     <font key="font" metaFont="system" size="15"/>
                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -794,7 +792,7 @@ Gw
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="1sE-hb-2L4"/>
                             </imageView>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="dNt-cn-mfd">
-                                <rect key="frame" x="18" y="409" width="333" height="14"/>
+                                <rect key="frame" x="18" y="410" width="333" height="14"/>
                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" sendsActionOnEndEditing="YES" id="W3b-zq-LTM">
                                     <font key="font" metaFont="smallSystem"/>
                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -835,7 +833,7 @@ Gw
     </scenes>
     <resources>
         <image name="DownloadsIcon" width="18" height="18"/>
-        <image name="NSRefreshTemplate" width="11" height="15"/>
+        <image name="NSRefreshTemplate" width="14" height="16"/>
         <image name="PlaceholderIcon" width="79" height="78.5"/>
     </resources>
 </document>

--- a/Doughnut/Utilities/NSView+Extensions.swift
+++ b/Doughnut/Utilities/NSView+Extensions.swift
@@ -1,0 +1,30 @@
+/*
+ * Doughnut Podcast Client
+ * Copyright (C) 2022 Ethan Wong
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import AppKit
+
+extension NSView {
+
+  var comptableSafeAreaLayoutGuide: Any {
+    if #available(macOS 11.0, *) {
+      return safeAreaLayoutGuide
+    }
+    return self
+  }
+
+}

--- a/Doughnut/View Controllers/DetailViewController.swift
+++ b/Doughnut/View Controllers/DetailViewController.swift
@@ -25,12 +25,14 @@ enum DetailViewType {
   case EpisodeDetail
 }
 
-class DetailViewController: NSViewController, WKNavigationDelegate {
+final class DetailViewController: NSViewController, WKNavigationDelegate {
+
   @IBOutlet weak var detailTitle: NSTextField!
   @IBOutlet weak var secondaryTitle: NSTextField!
   @IBOutlet weak var miniTitle: NSTextField!
   @IBOutlet weak var coverImage: NSImageView!
 
+  @IBOutlet weak var headerView: NSView!
   @IBOutlet weak var webView: WKWebView!
 
   let dateFormatter = DateFormatter()
@@ -82,11 +84,23 @@ class DetailViewController: NSViewController, WKNavigationDelegate {
     dateFormatter.dateStyle = .long
     view.wantsLayer = true
 
+    NSLayoutConstraint(
+      item: headerView!,
+      attribute: .top,
+      relatedBy: .equal,
+      toItem: view.comptableSafeAreaLayoutGuide,
+      attribute: .top,
+      multiplier: 1,
+      constant: 16
+    ).isActive = true
+
     if darkMode {
       view.layer?.backgroundColor = NSColor(calibratedRed: 0.220, green: 0.204, blue: 0.208, alpha: 1.00).cgColor
     } else {
       view.layer?.backgroundColor = CGColor.white
     }
+
+    showBlank()
 
     webView.navigationDelegate = self
     webView.loadHTMLString(MarkupGenerator.blankMarkup(), baseURL: nil)

--- a/Doughnut/View Controllers/EpisodeViewController.swift
+++ b/Doughnut/View Controllers/EpisodeViewController.swift
@@ -63,6 +63,20 @@ class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTableViewD
   override func viewDidLoad() {
     super.viewDidLoad()
 
+    if #available(macOS 11.0, *) {
+      tableView.style = .inset
+    }
+
+    NSLayoutConstraint(
+      item: sortView!,
+      attribute: .top,
+      relatedBy: .equal,
+      toItem: view.comptableSafeAreaLayoutGuide,
+      attribute: .top,
+      multiplier: 1,
+      constant: 0
+    ).isActive = true
+
     sortView.menuItemTitles = [
       EpisodeSortParameter.EpisodeFavourites.rawValue,
       EpisodeSortParameter.EpisodeMostRecent.rawValue,

--- a/Doughnut/View Controllers/PodcastViewController.swift
+++ b/Doughnut/View Controllers/PodcastViewController.swift
@@ -32,6 +32,10 @@ class PodcastViewController: NSViewController, NSTableViewDelegate, NSTableViewD
   @IBOutlet var tableView: NSTableView!
   @IBOutlet var sortView: SortingView!
 
+  private var tableScrollView: NSScrollView {
+    return tableView.enclosingScrollView!
+  }
+
   var filter: GlobalFilter = .All {
     didSet {
       reloadPodcasts()
@@ -58,6 +62,38 @@ class PodcastViewController: NSViewController, NSTableViewDelegate, NSTableViewD
 
   override func viewDidLoad() {
     super.viewDidLoad()
+
+    if #available(macOS 11.0, *) {
+      tableView.style = .sourceList
+
+      // NSTableView is not getting top inset at sourceList style,
+      // temporarily adding 10pt to inset to align with the episode list.
+      // The whole sidebar tableView should be migrated to a NSOutlineView.
+      let scrollViewTopInset: CGFloat = 10
+      tableScrollView.automaticallyAdjustsContentInsets = false
+      tableScrollView.contentInsets = NSEdgeInsets(
+        top: scrollViewTopInset,
+        left: 0,
+        bottom: 0,
+        right: 0
+      )
+      tableScrollView.scrollerInsets = NSEdgeInsets(
+        top: -scrollViewTopInset,
+        left: 0,
+        bottom: 0,
+        right: 0
+      )
+    }
+
+    NSLayoutConstraint(
+      item: tableScrollView,
+      attribute: .top,
+      relatedBy: .equal,
+      toItem: view.comptableSafeAreaLayoutGuide,
+      attribute: .top,
+      multiplier: 1,
+      constant: 0
+    ).isActive = true
 
     sortView.menuItemTitles = [
       PodcastSortParameter.PodcastTitle.rawValue,

--- a/Doughnut/Views/PlayerView.swift
+++ b/Doughnut/Views/PlayerView.swift
@@ -31,7 +31,9 @@ extension String {
 
 class PlayerView: NSView, PlayerDelegate {
   let width = 425
-  let baseline: CGFloat = 6
+  var baseline: CGFloat {
+    return frame.size.height / 2 - 13
+  }
 
   var loadingIdc: NSProgressIndicator!
   var artworkImg: NSImageView!
@@ -51,16 +53,16 @@ class PlayerView: NSView, PlayerDelegate {
   }
 
   required init?(coder decoder: NSCoder) {
-    loadingIdc = NSProgressIndicator(frame: NSRect(x: 25, y: baseline + 5, width: 16, height: 16))
-    artworkImg = NSImageView(frame: NSRect(x: 25, y: baseline + 3, width: 20, height: 20))
+    loadingIdc = NSProgressIndicator(frame: .zero)
+    artworkImg = NSImageView(frame: .zero)
 
-    reverseBtn = NSButton.init(frame: NSRect(x: PlayerView.controlX(artworkImg) + 6, y: baseline, width: 26, height: 25))
-    playBtn = NSButton.init(frame: NSRect(x: PlayerView.controlX(reverseBtn) + 1, y: baseline, width: 28, height: 26))
-    forwardBtn = NSButton.init(frame: NSRect(x: PlayerView.controlX(playBtn) + 1, y: baseline, width: 28, height: 26))
+    reverseBtn = NSButton.init(frame: .zero)
+    playBtn = NSButton.init(frame: .zero)
+    forwardBtn = NSButton.init(frame: .zero)
 
-    playedDurationLbl = NSTextField(frame: NSRect(x: PlayerView.controlX(forwardBtn) + 2, y: baseline + 6, width: 50, height: 14))
-    seekSlider = SeekSlider(frame: NSRect(x: PlayerView.controlX(playedDurationLbl) + 4, y: baseline + 4, width: 200, height: 18))
-    playedRemainingLbl = NSTextField(frame: NSRect(x: PlayerView.controlX(seekSlider) + 4, y: baseline + 6, width: 50, height: 14))
+    playedDurationLbl = NSTextField(frame: .zero)
+    seekSlider = SeekSlider(frame: .zero)
+    playedRemainingLbl = NSTextField(frame: .zero)
 
     super.init(coder: decoder)
     Player.global.delegate = self
@@ -128,60 +130,33 @@ class PlayerView: NSView, PlayerDelegate {
     playedRemainingLbl.font = NSFont.systemFont(ofSize: 10)
     playedRemainingLbl.isEditable = false
     addSubview(playedRemainingLbl)
- }
 
-  override func draw(_ dirtyRect: NSRect) {
-    let darkMode = DoughnutApp.darkMode()
-
-    if self.window?.isMainWindow ?? false {
-      var bgGradient = NSGradient(starting: NSColor(calibratedRed: 0.945, green: 0.945, blue: 0.945, alpha: 1.0), ending: NSColor(calibratedRed: 0.894, green: 0.894, blue: 0.894, alpha: 1.0))
-
-      NSColor(calibratedRed: 0.784, green: 0.784, blue: 0.784, alpha: 1.0).setStroke()
-
-      if darkMode {
-        bgGradient = NSGradient(starting: NSColor(calibratedRed: 0.170, green: 0.162, blue: 0.158, alpha: 1.00), ending: NSColor(calibratedRed: 0.220, green: 0.212, blue: 0.208, alpha: 1.00))
-
-        NSColor(calibratedRed: 0.180, green: 0.161, blue: 0.161, alpha: 1.0).setStroke()
-      }
-
-      bgGradient?.draw(in: self.bounds, angle: 270)
-
-    } else {
-      var bgGradient = NSGradient(starting: NSColor(calibratedRed: 0.980, green: 0.980, blue: 0.980, alpha: 1.0), ending: NSColor(calibratedRed: 0.980, green: 0.980, blue: 0.980, alpha: 1.0))
-
-      NSColor(calibratedRed: 0.902, green: 0.902, blue: 0.902, alpha: 1.0).setStroke()
-
-      if darkMode {
-        bgGradient = NSGradient(starting: NSColor(calibratedRed: 0.170, green: 0.162, blue: 0.158, alpha: 1.00), ending: NSColor(calibratedRed: 0.220, green: 0.212, blue: 0.208, alpha: 1.00))
-
-        NSColor(calibratedRed: 0.180, green: 0.161, blue: 0.161, alpha: 1.0).setStroke()
-      }
-
-      bgGradient?.draw(in: self.bounds, angle: 270)
+    wantsLayer = true
+    let backgroundColor = DoughnutApp.darkMode() ? NSColor.white.withAlphaComponent(0.04)
+                                                 : NSColor.black.withAlphaComponent(0.04)
+    var cornerRadius: CGFloat = 4
+    if #available(macOS 11.0, *) {
+      cornerRadius = 6
     }
+    layer?.backgroundColor = backgroundColor.cgColor
+    layer?.cornerRadius = cornerRadius
+  }
 
-    let leftBorder = NSBezierPath()
-    leftBorder.move(to: NSPoint(x: 0.5, y: 0))
-    leftBorder.line(to: NSPoint(x: 0.5, y: self.bounds.size.height))
-    leftBorder.stroke()
+  override func layout() {
+    resizeSubviews(withOldSize: NSZeroSize)
+  }
 
-    let rightBorder = NSBezierPath()
-    rightBorder.move(to: NSPoint(x: self.bounds.size.width - 0.5, y: 0))
-    rightBorder.line(to: NSPoint(x: self.bounds.size.width - 0.5, y: self.bounds.size.height))
-    rightBorder.stroke()
+  override func resizeSubviews(withOldSize oldSize: NSSize) {
+    loadingIdc.frame = NSRect(x: 25, y: baseline + 5, width: 16, height: 16)
+    artworkImg.frame = NSRect(x: 25, y: baseline + 3, width: 20, height: 20)
 
-    // Draw a solid black line at the bottom to match macOS's dark mode style
-    if darkMode {
-      NSColor.black.setStroke()
+    reverseBtn.frame = NSRect(x: PlayerView.controlX(artworkImg) + 6, y: baseline, width: 26, height: 25)
+    playBtn.frame = NSRect(x: PlayerView.controlX(reverseBtn) + 1, y: baseline, width: 28, height: 26)
+    forwardBtn.frame = NSRect(x: PlayerView.controlX(playBtn) + 1, y: baseline, width: 28, height: 26)
 
-      let bottomBorder = NSBezierPath()
-      bottomBorder.move(to: NSPoint(x: 0.5, y: 0))
-      bottomBorder.line(to: NSPoint(x: self.bounds.size.width - 0.5, y: 0))
-      bottomBorder.lineWidth = 1.5
-      bottomBorder.stroke()
-    }
-
-    super.draw(dirtyRect)
+    playedDurationLbl.frame = NSRect(x: PlayerView.controlX(forwardBtn) + 2, y: baseline + 6, width: 50, height: 14)
+    seekSlider.frame = NSRect(x: PlayerView.controlX(playedDurationLbl) + 4, y: baseline + 4, width: 200, height: 18)
+    playedRemainingLbl.frame = NSRect(x: PlayerView.controlX(seekSlider) + 4, y: baseline + 6, width: 50, height: 14)
   }
 
   func formatTime(total: Int) -> String {

--- a/Doughnut/Views/SortingView.swift
+++ b/Doughnut/Views/SortingView.swift
@@ -160,22 +160,6 @@ class SortingView: NSView {
     menuButtonView.updateLabel()
   }
 
-  override func draw(_ dirtyRect: NSRect) {
-    super.draw(dirtyRect)
-
-    let bottomBorder = NSBezierPath()
-    bottomBorder.move(to: NSPoint(x: 0, y: 0))
-    bottomBorder.line(to: NSPoint(x: bounds.width, y: 0))
-
-    if DoughnutApp.darkMode() {
-      NSColor.lightGray.setStroke()
-    } else {
-      NSColor.darkGray.setStroke()
-    }
-
-    bottomBorder.stroke()
-  }
-
   @objc func showMenu(_ sender: Any) {
     sortMenu.popUp(positioning: nil, at: NSPoint(x: menuButtonView.bounds.minX, y: menuButtonView.bounds.minY), in: self)
   }

--- a/Doughnut/WindowController.swift
+++ b/Doughnut/WindowController.swift
@@ -37,7 +37,21 @@ class WindowController: NSWindowController, NSWindowDelegate, NSTextFieldDelegat
 
   override func windowDidLoad() {
     super.windowDidLoad()
+
+    if #available(macOS 11.0, *) {
+      window?.toolbarStyle = .unified
+    } else {
+      window?.styleMask.remove(.fullSizeContentView)
+    }
+
     window?.titleVisibility = .hidden
+
+    window?.toolbar?.centeredItemIdentifier = playerView.itemIdentifier
+
+    // https://stackoverflow.com/questions/65723318/how-to-set-initial-width-of-nssearchtoolbaritem
+    searchInputView.addConstraint(
+      searchInputView.widthAnchor.constraint(lessThanOrEqualToConstant: 180)
+    )
 
     searchInputView.delegate = self
 


### PR DESCRIPTION
This PR is another trial towards modern appearance (but less intrusive to current interface structure) that includes:

1. For macOS 11 & newer, use `fullSizeContentView` for main window to extend the sidebar all the way to the top and use `NSWindowToolbarStyleUnified` to enable unified toolbar.
2. Adjusts all three columns to accommodate with the safe area, especially, wrap the detail entire header into a single view (a stackView for labels), so it's easier to manage edge constraints.
3. Moves the top bar of first column to bottom. A future PR will change the the button into icon-style [Gradient Button](https://developer.apple.com/design/human-interface-guidelines/macos/buttons/gradient-buttons/).
4. Assign correct `NSSplitViewItemBehavior` for each columns, and allow the sidebar column to collapse.
5. Replacing the gradient background of `PlayerView` with a semi-transparent, rounded corner one. `PlayerView` will be restricted to 32pt tall by AppKit after switching to the unified toolbar, which is slightly shorter than before.
6. Use proper toolbar item for search. Since `NSSearchToolbarItem` is still seems buggy, the old one that contains a `NSSearchField` is used.
7. Assign the `playerView` as toolbar's `centeredItemIdentifier` so that it's always centered, and fixed-width spacing items around are removed. Priorities are adjusted to make sure PlayerView and Search persists on the toolbar most of the time.

macOS 12:
<img width="1129" alt="Screen Shot 2022-01-13 at 22 40 06" src="https://user-images.githubusercontent.com/8158163/149350651-485beef3-5d5d-4ac4-910b-b62b8ab42c14.png">
<img width="1129" alt="Screen Shot 2022-01-13 at 22 39 42" src="https://user-images.githubusercontent.com/8158163/149350667-dc43e634-aed6-4d24-84a6-d4d17ce5349d.png">

macOS 10.15 (Screenshots are outdated, the sorting bar for episodes should be on top):
<img width="1136" alt="catalina-light" src="https://user-images.githubusercontent.com/8158163/149270685-9dc9b5ea-36f3-4e84-b64d-149299c6a17e.png">
<img width="1136" alt="catalina-dark" src="https://user-images.githubusercontent.com/8158163/149270693-a1026e04-e2e8-495a-b40a-0f77fe077a4a.png">