### PR TITLE
Add control menus to the Dock and correctly handle space keyEquivalent.

### DIFF
--- a/Doughnut.xcodeproj/project.pbxproj
+++ b/Doughnut.xcodeproj/project.pbxproj
@@ -10,9 +10,11 @@
 		1D7B5D7B127AE8F635350D7F /* Pods_DoughnutTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 558EE5E875BAF91152803575 /* Pods_DoughnutTests.framework */; };
 		2AB07BF789841271ED80EA26 /* Pods_DoughnutUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 25D4796441E8F7922FCDAF9A /* Pods_DoughnutUITests.framework */; };
 		4125A143137AD05319B3DEFC /* Pods_Doughnut.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2661E19A57B17099FC4ECCDD /* Pods_Doughnut.framework */; };
+		6B0233BD27B2CA6500500E28 /* ControlMenuProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0233BC27B2CA6500500E28 /* ControlMenuProvider.swift */; };
 		6B0605C52788627D00A8A91E /* NSMenu+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0605C42788627D00A8A91E /* NSMenu+Extensions.swift */; };
 		6B3A75F8278F44F500F25578 /* NSView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3A75F7278F44F500F25578 /* NSView+Extensions.swift */; };
 		6B94DF4C278968F500BCB149 /* NSTableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B94DF4B278968F500BCB149 /* NSTableView+Extensions.swift */; };
+		6B9C30BB27B5708300D462BE /* BaseTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9C30BA27B5708300D462BE /* BaseTableView.swift */; };
 		6BA21C4F279D690700CD3672 /* WindowController+Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA21C4E279D690700CD3672 /* WindowController+Toolbar.swift */; };
 		6BB5771E278602B400DFF99F /* MainMenu.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6BB5771C278602B400DFF99F /* MainMenu.storyboard */; };
 		6BF126D12780727100D840A4 /* EpisodeInfo.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6BF126D02780727100D840A4 /* EpisodeInfo.storyboard */; };
@@ -176,11 +178,13 @@
 		368B5540FC7D1B6258BCF776 /* Pods-DoughnutUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-DoughnutUITests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-DoughnutUITests/Pods-DoughnutUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		558EE5E875BAF91152803575 /* Pods_DoughnutTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_DoughnutTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E1DC050EEE121FD033C44DF /* Pods-Doughnut.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Doughnut.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Doughnut/Pods-Doughnut.debug.xcconfig"; sourceTree = "<group>"; };
+		6B0233BC27B2CA6500500E28 /* ControlMenuProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlMenuProvider.swift; sourceTree = "<group>"; };
 		6B0605C42788627D00A8A91E /* NSMenu+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMenu+Extensions.swift"; sourceTree = "<group>"; };
 		6B3A75F7278F44F500F25578 /* NSView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSView+Extensions.swift"; sourceTree = "<group>"; };
 		6B3ACC982773555700CF1EF1 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		6B730B732767A90900FB5F84 /* Doughnut-Release.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Doughnut-Release.entitlements"; sourceTree = "<group>"; };
 		6B94DF4B278968F500BCB149 /* NSTableView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTableView+Extensions.swift"; sourceTree = "<group>"; };
+		6B9C30BA27B5708300D462BE /* BaseTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableView.swift; sourceTree = "<group>"; };
 		6BA21C4E279D690700CD3672 /* WindowController+Toolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WindowController+Toolbar.swift"; sourceTree = "<group>"; };
 		6BB5771D278602B400DFF99F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainMenu.storyboard; sourceTree = "<group>"; };
 		6BF126D02780727100D840A4 /* EpisodeInfo.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = EpisodeInfo.storyboard; sourceTree = "<group>"; };
@@ -340,6 +344,7 @@
 				837D52BF1F8E683200C17514 /* DownloadCellView.swift */,
 				834CC1B21F950ABA00A98DE9 /* DetailWebView.swift */,
 				839DBDA61FEEEA81007610EF /* WhiteBackgroundView.swift */,
+				6B9C30BA27B5708300D462BE /* BaseTableView.swift */,
 				834998B51FF3E3F00035EF87 /* TaskManagerView.swift */,
 				830E99BC1FF50DD000B728BE /* ActivityIndicator.swift */,
 				8389709B20069D720094795D /* SortingMenuProvider.swift */,
@@ -451,6 +456,7 @@
 				838257CD1F759F6F00DB4FD1 /* AppDelegate.swift */,
 				83BA22E21F994EA6006BF58A /* DoughnutApp.swift */,
 				83D971091F812B270091822A /* Player.swift */,
+				6B0233BC27B2CA6500500E28 /* ControlMenuProvider.swift */,
 				832A04331F76EBDC00C92D25 /* WindowController.swift */,
 				6BA21C4E279D690700CD3672 /* WindowController+Toolbar.swift */,
 				832BB7511F95184700988AE8 /* Doughnut-Bridging-Header.h */,
@@ -844,6 +850,7 @@
 				83EFC6051F9954AD00E1DE1F /* NSObject+SPInvocationGrabbing.m in Sources */,
 				83E95A5E1FFBCA3C00C6AABF /* Storage.swift in Sources */,
 				8341B83B1F7BEB0500B50A5D /* Migrations.swift in Sources */,
+				6B9C30BB27B5708300D462BE /* BaseTableView.swift in Sources */,
 				83A0D4831FFC2FA400A376FD /* TaskQueue.swift in Sources */,
 				83667DF01F76D20C00F1ABC0 /* PodcastViewController.swift in Sources */,
 				83D9710C1F812E910091822A /* PlayerView.swift in Sources */,
@@ -851,6 +858,7 @@
 				6B0605C52788627D00A8A91E /* NSMenu+Extensions.swift in Sources */,
 				6BA21C4F279D690700CD3672 /* WindowController+Toolbar.swift in Sources */,
 				839DBDA41FEEE658007610EF /* ShowPodcastWindow.swift in Sources */,
+				6B0233BD27B2CA6500500E28 /* ControlMenuProvider.swift in Sources */,
 				83D9710A1F812B270091822A /* Player.swift in Sources */,
 				83EFC6041F9954A500E1DE1F /* SPMediaKeyTap.m in Sources */,
 				837D52C01F8E683200C17514 /* DownloadCellView.swift in Sources */,

--- a/Doughnut/AppDelegate.swift
+++ b/Doughnut/AppDelegate.swift
@@ -24,6 +24,7 @@ private extension NSUserInterfaceItemIdentifier {
 
   static let doughnutViewMenuSortPodcasts = Self("NSDoughnutViewMenuSortPodcastsItem")
   static let doughnutViewMenuSortEpisodes = Self("NSDoughnutViewMenuSortEpisodesItem")
+  static let doughnutControlMenu = Self("NSDoughnutControlMenuItem")
 
 }
 
@@ -84,6 +85,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
   func applicationWillTerminate(_ aNotification: Notification) {
     // Insert code here to tear down your application
+  }
+
+  func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
+    let menu = NSMenu()
+    menu.items = ControlMenuProvider.shared.buildControlMenuItems(isForDockMenu: true)
+    return menu
   }
 
   override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
@@ -164,6 +171,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 extension AppDelegate: NSMenuDelegate {
 
   func menuNeedsUpdate(_ menu: NSMenu) {
+    if let menuItem = menu.menuItem, let identifier = menuItem.identifier {
+      switch identifier {
+      case .doughnutControlMenu:
+        menu.items = ControlMenuProvider.shared.buildControlMenuItems(isForDockMenu: false)
+      default:
+        break
+      }
+    }
+
     for menuItem in menu.items {
       // Hide main menu items that is not impelemented for release build.
       switch menuItem.action {

--- a/Doughnut/Base.lproj/Main.storyboard
+++ b/Doughnut/Base.lproj/Main.storyboard
@@ -380,7 +380,7 @@ Gw
                                     <rect key="frame" x="0.0" y="0.0" width="251" height="401"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnSelection="YES" columnResizing="NO" autosaveColumns="NO" rowHeight="55" viewBased="YES" id="aVy-1A-ODd">
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnSelection="YES" columnResizing="NO" autosaveColumns="NO" rowHeight="55" viewBased="YES" id="aVy-1A-ODd" customClass="BaseTableView" customModule="Doughnut" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="0.0" width="251" height="401"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="0.0" height="4"/>
@@ -605,7 +605,7 @@ Gw
                                     <rect key="frame" x="0.0" y="0.0" width="351" height="400"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" autosaveColumns="NO" rowHeight="76" viewBased="YES" id="Xrx-cp-IWJ">
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" autosaveColumns="NO" rowHeight="76" viewBased="YES" id="Xrx-cp-IWJ" customClass="BaseTableView" customModule="Doughnut" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="0.0" width="351" height="400"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/Doughnut/Base.lproj/MainMenu.storyboard
+++ b/Doughnut/Base.lproj/MainMenu.storyboard
@@ -413,39 +413,9 @@ CA
                                     </items>
                                 </menu>
                             </menuItem>
-                            <menuItem title="Control" id="WLk-DP-BZ5">
+                            <menuItem title="Control" identifier="NSDoughnutControlMenuItem" id="WLk-DP-BZ5">
                                 <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Control" id="222-rP-pvk">
-                                    <items>
-                                        <menuItem title="Backward 30 seconds" keyEquivalent="" id="Bdi-lX-YGo">
-                                            <connections>
-                                                <action selector="playerBackward:" target="Ady-hI-5gd" id="hTx-1L-HGE"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="Play" id="BLT-Qs-aQt">
-                                            <modifierMask key="keyEquivalentModifierMask"/>
-                                            <connections>
-                                                <action selector="playerPlay:" target="Ady-hI-5gd" id="Nvp-ru-1xS"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="Forward 30 seconds" keyEquivalent="" id="Jxl-SS-SIr">
-                                            <connections>
-                                                <action selector="playerForward:" target="Ady-hI-5gd" id="AXf-Y2-6k2"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem isSeparatorItem="YES" id="ir9-XQ-Nwc"/>
-                                        <menuItem title="Increase Volume" keyEquivalent="" id="DFF-RD-r67">
-                                            <connections>
-                                                <action selector="volumeUp:" target="Ady-hI-5gd" id="Qln-aq-N4Z"/>
-                                            </connections>
-                                        </menuItem>
-                                        <menuItem title="Decrease Volume" keyEquivalent="" id="yFw-DO-DFl">
-                                            <connections>
-                                                <action selector="volumeDown:" target="Ady-hI-5gd" id="PJm-Rn-vaV"/>
-                                            </connections>
-                                        </menuItem>
-                                    </items>
-                                </menu>
+                                <menu key="submenu" title="Control" id="222-rP-pvk"/>
                             </menuItem>
                             <menuItem title="Window" id="aUF-d1-5bR">
                                 <modifierMask key="keyEquivalentModifierMask"/>

--- a/Doughnut/ControlMenuProvider.swift
+++ b/Doughnut/ControlMenuProvider.swift
@@ -1,0 +1,166 @@
+/*
+ * Doughnut Podcast Client
+ * Copyright (C) 2022 Ethan Wong
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+final class ControlMenuProvider {
+
+  static let shared = ControlMenuProvider()
+
+  private init() { }
+
+  func buildControlMenuItems(isForDockMenu: Bool) -> [NSMenuItem] {
+    var menuItems = [NSMenuItem]()
+
+    let player = Player.global
+    let isCurrentlyPlaying = player.currentEpisode != nil
+
+    // Now Playing
+    if
+      isForDockMenu,
+      isCurrentlyPlaying,
+      let currentEpisode = player.currentEpisode,
+      !currentEpisode.title.isEmpty
+    {
+      let formatNowPlayingTitle: (Episode) -> String = { episode in
+        if let podcastTitle = episode.podcast?.title {
+          return "\(episode.title) - \(podcastTitle)"
+        } else {
+          return episode.title
+        }
+      }
+
+      menuItems.append(
+        NSMenuItem(
+          title: "Now Playing",
+          action: nil,
+          keyEquivalent: ""
+        )
+      )
+
+      let nowPlayingItem = NSMenuItem(
+        title: formatNowPlayingTitle(currentEpisode),
+        action: nil,
+        keyEquivalent: ""
+      )
+      nowPlayingItem.indentationLevel = 1
+      menuItems.append(nowPlayingItem)
+
+      menuItems.append(.separator())
+    }
+
+    // Play / Pause
+    let togglePlayItem = NSMenuItem(
+      title: player.isPlaying ? "Pause" : "Play",
+      action: #selector(playerToggle(_:)),
+      keyEquivalent: " "
+    )
+    togglePlayItem.target = self
+    togglePlayItem.keyEquivalentModifierMask = []
+    togglePlayItem.isEnabled = isCurrentlyPlaying
+    menuItems.append(togglePlayItem)
+
+    // Skip / Rewind
+    if !isForDockMenu || isCurrentlyPlaying {
+      let skipForwardDuration = Preference.double(for: Preference.Key.skipForwardDuration)
+      let skipBackawrdDuration = Preference.double(for: Preference.Key.skipBackDuration)
+
+      let formatSkipping: (String, TimeInterval) -> String = { title, duration in
+        if duration >= 60 {
+          return "\(title) \(Int(duration / 60)) Minutes"
+        } else {
+          return "\(title) \(Int(duration)) Seconds"
+        }
+      }
+
+      // Skip
+      let skipForwardItem = NSMenuItem(
+        title: formatSkipping("Skip", skipForwardDuration),
+        action: #selector(playerForward(_:)),
+        keyEquivalent: String(Unicode.Scalar(NSRightArrowFunctionKey)!)
+      )
+      skipForwardItem.target = self
+      skipForwardItem.isEnabled = isCurrentlyPlaying
+      menuItems.append(skipForwardItem)
+
+      // Rewind
+      let skipBackwardItem = NSMenuItem(
+        title: formatSkipping("Rewind", skipBackawrdDuration),
+        action: #selector(playerBackward(_:)),
+        keyEquivalent: String(Unicode.Scalar(NSLeftArrowFunctionKey)!)
+      )
+      skipBackwardItem.target = self
+      skipBackwardItem.isEnabled = isCurrentlyPlaying
+      menuItems.append(skipBackwardItem)
+    }
+
+    if !isForDockMenu {
+      // Seperator
+      menuItems.append(.separator())
+
+      // Volume Up
+      let volumeUpItem = NSMenuItem(
+        title: "Increase Volume",
+        action: #selector(volumeUp(_:)),
+        keyEquivalent: String(Unicode.Scalar(NSUpArrowFunctionKey)!)
+      )
+      volumeUpItem.target = self
+      menuItems.append(volumeUpItem)
+
+      // Volume Down
+      let volumeDownItem = NSMenuItem(
+        title: "Decrease Volume",
+        action: #selector(volumeDown(_:)),
+        keyEquivalent: String(Unicode.Scalar(NSDownArrowFunctionKey)!)
+      )
+      volumeDownItem.target = self
+      menuItems.append(volumeDownItem)
+    }
+
+    return menuItems
+  }
+
+  @objc func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+    return menuItem.isEnabled
+  }
+
+  // Actions
+
+  @objc func playerBackward(_ sender: Any) {
+    Player.global.skipBack()
+  }
+
+  @objc func playerToggle(_ sender: Any) {
+    Player.global.togglePlay()
+  }
+
+  @objc func playerForward(_ sender: Any) {
+    Player.global.skipAhead()
+  }
+
+  @objc func volumeUp(_ sender: Any) {
+    let current = Player.global.volume
+    Player.global.volume = min(current + 0.1, 1.0)
+  }
+
+  @objc func volumeDown(_ sender: Any) {
+    let current = Player.global.volume
+    Player.global.volume = max(current - 0.1, 0.0)
+  }
+
+}

--- a/Doughnut/Utilities/NSMenu+Extensions.swift
+++ b/Doughnut/Utilities/NSMenu+Extensions.swift
@@ -45,6 +45,12 @@ extension NSMenu {
     return current!
   }
 
+  var menuItem: NSMenuItem? {
+    return supermenu?.items.first {
+      $0.submenu == self
+    }
+  }
+
 }
 
 extension NSMenuItem {

--- a/Doughnut/View Controllers/EpisodeViewController.swift
+++ b/Doughnut/View Controllers/EpisodeViewController.swift
@@ -215,9 +215,14 @@ final class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTabl
     return result
   }
 
-  func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
-    viewController.selectEpisode(episode: episodes[row])
-    return true
+  func tableViewSelectionDidChange(_ notification: Notification) {
+    let episodeToSelect: Episode?
+    if tableView.selectedRow != -1, tableView.selectedRow < episodes.count {
+      episodeToSelect = episodes[tableView.selectedRow]
+    } else {
+      episodeToSelect = nil
+    }
+    viewController.selectEpisode(episode: episodeToSelect)
   }
 
   func tableView(_ tableView: NSTableView, validateDrop info: NSDraggingInfo, proposedRow row: Int, proposedDropOperation dropOperation: NSTableView.DropOperation) -> NSDragOperation {

--- a/Doughnut/View Controllers/PodcastViewController.swift
+++ b/Doughnut/View Controllers/PodcastViewController.swift
@@ -201,10 +201,15 @@ final class PodcastViewController: NSViewController, NSTableViewDelegate, NSTabl
     return result
   }
 
-  func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
+  func tableViewSelectionDidChange(_ notification: Notification) {
     //NotificationCenter.default.post(name: ViewController.Events.PodcastSelected.notification, object: nil, userInfo: ["podcast": podcasts[row]])
-    viewController.selectPodcast(podcast: podcasts[row])
-    return true
+    let podcastToSelect: Podcast?
+    if tableView.selectedRow != -1, tableView.selectedRow < podcasts.count {
+      podcastToSelect = podcasts[tableView.selectedRow]
+    } else {
+      podcastToSelect = nil
+    }
+    viewController.selectPodcast(podcast: podcastToSelect)
   }
 
   private func activePodcastsForAction() -> [Podcast] {

--- a/Doughnut/Views/BaseTableView.swift
+++ b/Doughnut/Views/BaseTableView.swift
@@ -1,0 +1,35 @@
+/*
+ * Doughnut Podcast Client
+ * Copyright (C) 2022 Ethan Wong
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import AppKit
+
+final class BaseTableView: NSTableView {
+
+  override func responds(to selector: Selector!) -> Bool {
+    // NSWindow converts certain keys that control UI into actions.
+    // For the 'Space' menu key equivalent to work properly, we need to prevent
+    // 'performClick:' from being called, so that the event has a chance to
+    // propagate to the main menu.
+    //
+    // See https://stackoverflow.com/questions/11155239/nsmenuitem-keyequivalent-space-bug#54006299
+    // for detailed explanations.
+    if selector == #selector(performClick(_:)) { return false }
+    return super.responds(to: selector)
+  }
+
+}

--- a/Doughnut/WindowController.swift
+++ b/Doughnut/WindowController.swift
@@ -56,23 +56,6 @@ final class WindowController: NSWindowController, NSWindowDelegate, NSTextFieldD
     searchInputView.delegate = self
 
     Library.global.downloadManager.delegate = self
-
-    NSEvent.addLocalMonitorForEvents(matching: .keyDown) {
-      if self.keyDown(with: $0) {
-        return nil
-      } else {
-        return $0
-      }
-    }
-  }
-
-  func keyDown(with event: NSEvent) -> Bool {
-    if event.characters == " " {
-      Player.global.togglePlay()
-      return true
-    } else {
-      return false
-    }
   }
 
   // Subscribed to Search input changes
@@ -147,29 +130,6 @@ final class WindowController: NSWindowController, NSWindowDelegate, NSTextFieldD
     if let player = playerView.view as? PlayerView {
       player.needsDisplay = true
     }
-  }
-
-  // Control Menu
-  @IBAction func playerBackward(_ sender: Any) {
-    Player.global.skipBack()
-  }
-
-  @IBAction func playerPlay(_ sender: Any) {
-    Player.global.play()
-  }
-
-  @IBAction func playerForward(_ sender: Any) {
-    Player.global.skipAhead()
-  }
-
-  @IBAction func volumeUp(_ sender: Any) {
-    let current = Player.global.volume
-    Player.global.volume = min(current + 0.1, 1.0)
-  }
-
-  @IBAction func volumeDown(_ sender: Any) {
-    let current = Player.global.volume
-    Player.global.volume = max(current - 0.1, 0.0)
   }
 
 }


### PR DESCRIPTION
This PR:
1. Uses `ControlMenuProvider` to dynamically build 'control' menu that responds to current playback status and reflects skipping seconds set in the preference.
2. Adds a control menu to the dock (including basic controls and now playing status).
3. [Correctly](https://stackoverflow.com/questions/11155239/nsmenuitem-keyequivalent-space-bug#54006299) handles the space key for play/pause as a menu key equivalent instead of directly intercepting the event. Previous implementation prevents space characters being entered into the search bar.

Menu items being grayed out when no episode is being played:
<img width="382" alt="Screen Shot 2022-02-11 at 00 55 44" src="https://user-images.githubusercontent.com/8158163/153457315-07654078-13eb-4a4d-8496-d0e5ad71deaf.png">

Dock menu:
<img width="599" alt="Screen Shot 2022-02-11 at 00 56 48" src="https://user-images.githubusercontent.com/8158163/153457302-1a12bc0a-c2b2-42c0-af8a-b56817b8dacc.png">