### PR TITLE
Support for user-defined accent color.

### DIFF
--- a/Doughnut.xcodeproj/project.pbxproj
+++ b/Doughnut.xcodeproj/project.pbxproj
@@ -1092,6 +1092,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = F42DD5B957A39D2CA878BEA8 /* Pods-Doughnut.test.xcconfig */;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Doughnut/Doughnut-Debug.entitlements";
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
@@ -1285,6 +1286,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5E1DC050EEE121FD033C44DF /* Pods-Doughnut.debug.xcconfig */;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Doughnut/Doughnut-Debug.entitlements";
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
@@ -1308,6 +1310,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = BA7A57F62DAF0A2C3DA2C7AF /* Pods-Doughnut.release.xcconfig */;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Doughnut/Doughnut-Release.entitlements";
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Automatic;

--- a/Doughnut/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Doughnut/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9B",
+          "green" : "0x46",
+          "red" : "0xFA"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xA2",
+          "green" : "0x58",
+          "red" : "0xF5"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Doughnut/Views/EpisodeCellView.swift
+++ b/Doughnut/Views/EpisodeCellView.swift
@@ -60,8 +60,8 @@ class EpisodeCellView: NSTableCellView {
     guard let episode = episode else { return }
 
     let selected = backgroundStyle == .dark
-    let selectedBlue = NSColor(calibratedRed: 0.090, green: 0.433, blue: 0.937, alpha: 1.0)
-    var selectedColor = selectedBlue
+    let selectedAccent = NSColor.controlAccentColor
+    var selectedColor = selectedAccent
     if selected {
       selectedColor = NSColor.white
     }
@@ -84,7 +84,7 @@ class EpisodeCellView: NSTableCellView {
 
       // Draw download arrow
       if selected {
-        selectedBlue.setFill()
+        selectedAccent.setFill()
       } else {
         NSColor.white.setFill()
       }
@@ -126,7 +126,7 @@ class EpisodeCellView: NSTableCellView {
         if backgroundStyle == .dark {
           selectedColor.setFill()
         } else {
-          selectedBlue.setFill()
+          selectedAccent.setFill()
         }
         playedSlice.fill()
       } else {

--- a/Doughnut/Views/EpisodeCellView.swift
+++ b/Doughnut/Views/EpisodeCellView.swift
@@ -135,7 +135,9 @@ class EpisodeCellView: NSTableCellView {
       }
     }
 
-    drawBottomBorder()
+    if #available(macOS 11.0, *) { } else {
+      drawBottomBorder()
+    }
   }
 
   override var backgroundStyle: NSView.BackgroundStyle {

--- a/Doughnut/Views/PodcastCellView.swift
+++ b/Doughnut/Views/PodcastCellView.swift
@@ -96,8 +96,7 @@ class PodcastUnplayedCountView: NSView {
       let bg = NSBezierPath(roundedRect: bgRect, xRadius: 5, yRadius: 5)
 
       if highlightColor {
-        let selectedBlue = NSColor(calibratedRed: 0.090, green: 0.433, blue: 0.937, alpha: 1.0)
-        selectedBlue.setFill()
+        NSColor.black.withAlphaComponent(0.15).setFill()
       } else {
         NSColor.gray.setFill()
       }


### PR DESCRIPTION
This PR adjusts drawing code to use `NSColor.controlAccentColor` to adhere to user-defined accent color, instead of drawing all interface elements in blue.

The last commit adds a Doughnut specific pink accent color. It's just an experiment for the multi-color feature and the color is derived from the app icon. Feel free to discard this commit or further tune the color.

Here's what it looks like:
<img width="1148" alt="Screen Shot 2022-02-17 at 00 26 40" src="https://user-images.githubusercontent.com/8158163/154310498-adf4381d-8d36-40a1-af40-fafa7468a10c.png">
<img width="1148" alt="Screen Shot 2022-02-17 at 00 28 43" src="https://user-images.githubusercontent.com/8158163/154310986-6a7c059e-fb97-490c-a142-a3abf09ec2b0.png">