### PR TITLE
Refinements for selection updating behavior.

### DIFF
--- a/Doughnut/AppDelegate.swift
+++ b/Doughnut/AppDelegate.swift
@@ -69,13 +69,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
       try Player.audioOutputDevices()
     } catch {}*/
 
+    createAndShowMainWindow()
+
     let connected = Library.global.connect()
 
     if !connected {
       abort()
     }
-
-    createAndShowMainWindow()
   }
 
   func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {

--- a/Doughnut/Library/Library.swift
+++ b/Doughnut/Library/Library.swift
@@ -418,10 +418,6 @@ class Library: NSObject {
 
         DispatchQueue.main.async {
           self.delegate?.libraryUpdatedEpisode(episode: episode)
-
-          if let parent = episode.podcast {
-            self.delegate?.libraryUpdatedPodcast(podcast: parent)
-          }
         }
       })
     }

--- a/Doughnut/View Controllers/EpisodeViewController.swift
+++ b/Doughnut/View Controllers/EpisodeViewController.swift
@@ -200,10 +200,8 @@ final class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTabl
     tableView.selectRowIndexes(IndexSet(integer: selectedRow), byExtendingSelection: false)
   }
 
-  func reloadEpisode(_ episode: Episode) {
-    if let index = episodes.firstIndex(where: { e -> Bool in
-      e.id == episode.id
-    }) {
+  func reload(forEpisode episode: Episode) {
+    if let index = episodes.firstIndex(where: { $0.id == episode.id }) {
       tableView.reloadData(forRowIndexes: IndexSet.init(integer: index), columnIndexes: IndexSet.init(integer: 0))
     }
   }

--- a/Doughnut/View Controllers/EpisodeViewController.swift
+++ b/Doughnut/View Controllers/EpisodeViewController.swift
@@ -154,17 +154,21 @@ final class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTabl
   }
 
   func reloadEpisodes() {
+    let previousSelectedEpisodeIds = tableView.selectedRowIndexes.compactMap {
+      return episodes[$0].id
+    }
+
     if let podcast = podcast {
       episodes = podcast.episodes
 
       // Global All | New filter
-      episodes = episodes.filter({ episode -> Bool in
+      episodes = episodes.filter { episode -> Bool in
         if filter == .unplayed {
           return !episode.played
         } else {
           return true
         }
-      })
+      }
 
       // Filter based on possible search query
       if let query = searchQuery {
@@ -195,9 +199,24 @@ final class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTabl
     if episodes.isEmpty {
     }
 
-    let selectedRow = tableView.selectedRow
     tableView.reloadData()
-    tableView.selectRowIndexes(IndexSet(integer: selectedRow), byExtendingSelection: false)
+
+    let episodeIdToIndexMap = episodes.enumerated().reduce(into: [Int64: Int]()) { dict, pair in
+      let (index, podcast) = pair
+      if let id = podcast.id {
+        dict[id] = index
+      }
+    }
+
+    let selectionIndices = episodeIdToIndexMap.compactMap { pair -> Int? in
+      return previousSelectedEpisodeIds.contains(pair.key) ? pair.value : nil
+    }
+
+    tableView.selectRowIndexes(IndexSet(selectionIndices), byExtendingSelection: false)
+    if selectionIndices.isEmpty {
+      viewController.selectEpisode(episode: nil)
+    }
+    tableView.scrollRowToVisible(tableView.selectedRow)
   }
 
   func reload(forEpisode episode: Episode) {

--- a/Doughnut/View Controllers/PodcastViewController.swift
+++ b/Doughnut/View Controllers/PodcastViewController.swift
@@ -166,6 +166,12 @@ final class PodcastViewController: NSViewController, NSTableViewDelegate, NSTabl
     tableView.selectRowIndexes(IndexSet(integer: selectedRow), byExtendingSelection: false)
   }
 
+  func reload(forPodcast podcast: Podcast) {
+    if let index = podcasts.firstIndex(where: { $0.id == podcast.id }) {
+      tableView.reloadData(forRowIndexes: IndexSet(integer: index), columnIndexes: IndexSet(integer: 0))
+    }
+  }
+
   func numberOfRows(in tableView: NSTableView) -> Int {
     return podcasts.count
   }

--- a/Doughnut/View Controllers/PodcastViewController.swift
+++ b/Doughnut/View Controllers/PodcastViewController.swift
@@ -92,8 +92,6 @@ final class PodcastViewController: NSViewController, NSTableViewDelegate, NSTabl
     sortingMenuProvider.sortParam = sortBy.rawValue
     sortingMenuProvider.sortDirection = sortDirection
     sortingMenuProvider.delegate = self
-
-    reloadPodcasts()
   }
 
   override func viewDidAppear() {
@@ -128,15 +126,19 @@ final class PodcastViewController: NSViewController, NSTableViewDelegate, NSTabl
   }
 
   func reloadPodcasts() {
+    let previousSelectedPodcastIds = tableView.selectedRowIndexes.compactMap {
+      return podcasts[$0].id
+    }
+
     podcasts = Library.global.podcasts
 
-    podcasts = podcasts.filter({ podcast -> Bool in
+    podcasts = podcasts.filter { podcast -> Bool in
       if filter == .newEpisodes {
         return podcast.unplayedCount > 0
       } else {
         return true
       }
-    })
+    }
 
     // Sort into ascending order
     podcasts.sort { (a, b) -> Bool in
@@ -161,9 +163,24 @@ final class PodcastViewController: NSViewController, NSTableViewDelegate, NSTabl
       podcasts.reverse()
     }
 
-    let selectedRow = tableView.selectedRow
     tableView.reloadData()
-    tableView.selectRowIndexes(IndexSet(integer: selectedRow), byExtendingSelection: false)
+
+    let podcastIdToIndexMap = podcasts.enumerated().reduce(into: [Int64: Int]()) { dict, pair in
+      let (index, podcast) = pair
+      if let id = podcast.id {
+        dict[id] = index
+      }
+    }
+
+    let selectionIndices = podcastIdToIndexMap.compactMap { pair -> Int? in
+      return previousSelectedPodcastIds.contains(pair.key) ? pair.value : nil
+    }
+
+    tableView.selectRowIndexes(IndexSet(selectionIndices), byExtendingSelection: false)
+    if selectionIndices.isEmpty {
+      viewController.selectPodcast(podcast: nil)
+    }
+    tableView.scrollRowToVisible(tableView.selectedRow)
   }
 
   func reload(forPodcast podcast: Podcast) {

--- a/Doughnut/View Controllers/ViewController.swift
+++ b/Doughnut/View Controllers/ViewController.swift
@@ -104,12 +104,12 @@ final class ViewController: NSSplitViewController, LibraryDelegate {
   }
 
   func libraryUpdatingPodcast(podcast: Podcast) {
-    podcastViewController.reloadPodcasts()
+    podcastViewController.reload(forPodcast: podcast)
     updateWindowTitleAndDockIcon()
   }
 
   func libraryUpdatedPodcast(podcast: Podcast) {
-    podcastViewController.reloadPodcasts()
+    podcastViewController.reload(forPodcast: podcast)
 
     if episodeViewController.podcast?.id == podcast.id {
       episodeViewController.reloadEpisodes()
@@ -120,7 +120,11 @@ final class ViewController: NSSplitViewController, LibraryDelegate {
 
   func libraryUpdatedEpisode(episode: Episode) {
     if episodeViewController.podcast?.id == episode.podcastId {
-      episodeViewController.reloadEpisode(episode)
+      episodeViewController.reload(forEpisode: episode)
+    }
+
+    if let podcast = episode.podcast {
+      podcastViewController.reload(forPodcast: podcast)
     }
 
     updateWindowTitleAndDockIcon()

--- a/DoughnutTests/LibraryTests/LibraryTestsWithSubscription.swift
+++ b/DoughnutTests/LibraryTests/LibraryTestsWithSubscription.swift
@@ -180,7 +180,7 @@ class LibraryTestsWithSubscription: LibraryTestCase {
 
     let spy = LibrarySpyDelegate()
     Library.global.delegate = spy
-    spy.updatedPodcastExpectation = self.expectation(description: "Library updated episode")
+    spy.updatedEpisodeExpectation = self.expectation(description: "Library updated episode")
 
     episode.title = "This is the new episode"
     Library.global.save(episode: episode)


### PR DESCRIPTION
This PR refines the behaviors of tableView selection updates, especially:
1. Prevent frequent selection changes. The podcast list was frequently being force-selected when fetching new episodes and during periodic playback progress saves.
2. Preserve previously selected items after filtering podcasts or episodes.