### PR TITLE
Improve list update performance and fix inconsistency.

### DIFF
--- a/Doughnut/Base.lproj/Main.storyboard
+++ b/Doughnut/Base.lproj/Main.storyboard
@@ -518,6 +518,7 @@ Gw
                         <viewLayoutGuide key="layoutMargins" id="8eP-ga-5Bq"/>
                     </view>
                     <connections>
+                        <outlet property="filterBarSeperator" destination="Q9V-7G-TPX" id="9In-cD-HGh"/>
                         <outlet property="moreButton" destination="Pkz-GU-AL9" id="O9K-hE-JvA"/>
                         <outlet property="searchField" destination="mtS-jJ-Pmb" id="OFh-oJ-WxW"/>
                         <outlet property="sortView" destination="Mge-rT-KIQ" id="UXl-BK-k3s"/>

--- a/Doughnut/Utilities/NSTableView+Extensions.swift
+++ b/Doughnut/Utilities/NSTableView+Extensions.swift
@@ -27,4 +27,24 @@ extension NSTableView {
     return selectedRowIndexes
   }
 
+  var availableRowIndices: IndexSet {
+    var avaliableIndices = IndexSet()
+    enumerateAvailableRowViews { _, index in
+      avaliableIndices.insert(index)
+    }
+    return avaliableIndices
+  }
+
+  var availableRowIndicesRange: Range<Int> {
+    let availableRowIndices = availableRowIndices
+    if !availableRowIndices.isEmpty {
+      return Range((availableRowIndices.min()!)...(availableRowIndices.max()!))
+    }
+    return 0..<0
+  }
+
+  func reloadData(forRowIndexes rowIndexes: IndexSet) {
+    reloadData(forRowIndexes: rowIndexes, columnIndexes: IndexSet(0..<numberOfColumns))
+  }
+
 }

--- a/Doughnut/View Controllers/DetailViewController.swift
+++ b/Doughnut/View Controllers/DetailViewController.swift
@@ -103,13 +103,15 @@ final class DetailViewController: NSViewController, WKNavigationDelegate {
     showBlank()
 
     webView.navigationDelegate = self
-    webView.loadHTMLString(MarkupGenerator.blankMarkup(), baseURL: nil)
   }
 
   func showBlank() {
     detailTitle.stringValue = ""
     secondaryTitle.stringValue = ""
     miniTitle.stringValue = ""
+    coverImage.image = nil
+
+    webView.loadHTMLString(MarkupGenerator.blankMarkup(), baseURL: nil)
   }
 
   func showPodcast() {

--- a/Doughnut/View Controllers/EpisodeViewController.swift
+++ b/Doughnut/View Controllers/EpisodeViewController.swift
@@ -154,7 +154,19 @@ final class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTabl
   }
 
   func reloadEpisodes() {
-    let previousSelectedEpisodeIds = tableView.selectedRowIndexes.compactMap {
+    reload(forChangedEpisodes: nil)
+    tableView.scrollRowToVisible(tableView.selectedRow)
+  }
+
+  func reload(forEpisode episode: Episode) {
+    reload(forChangedEpisodes: [episode])
+  }
+
+  func reload(forChangedEpisodes changedEpisodes: [Episode]?) {
+    let availableRowIndicesRange = tableView.availableRowIndicesRange
+
+    let episodeIdsBeforeReload = episodes.map { $0.id }
+    let selectedEpisodeIdsBeforeReload = tableView.selectedRowIndexes.compactMap {
       return episodes[$0].id
     }
 
@@ -199,29 +211,51 @@ final class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTabl
     if episodes.isEmpty {
     }
 
-    tableView.reloadData()
+    let episodeIdsAfterReload = episodes.map { $0.id }
 
     let episodeIdToIndexMap = episodes.enumerated().reduce(into: [Int64: Int]()) { dict, pair in
-      let (index, podcast) = pair
-      if let id = podcast.id {
+      let (index, item) = pair
+      if let id = item.id {
         dict[id] = index
       }
     }
 
+    if episodeIdsBeforeReload.count != episodeIdsAfterReload.count {
+      // if item count being changed, a full reload is needed, which triggers `numberOfRowsInTableView:` call
+      tableView.reloadData()
+    } else {
+      // take the short path to only reload at most items in availableRowIndicesRange
+      if let changedEpisodes = changedEpisodes {
+        let changedIds = changedEpisodes.map { $0.id }
+        let changedIndices = episodeIdToIndexMap.compactMap { pair -> Int? in
+          return changedIds.contains(pair.key) ? pair.value : nil
+        }
+        let indicesToReload = availableRowIndicesRange.filter { index in
+          if changedIndices.contains(index) {
+            return true
+          } else {
+            guard index < episodeIdsBeforeReload.count, index < episodeIdsAfterReload.count else {
+              return false
+            }
+            return episodeIdsBeforeReload[index] != episodeIdsAfterReload[index]
+          }
+        }
+        tableView.reloadData(forRowIndexes: IndexSet(indicesToReload))
+      } else {
+        // otherwise, reload the entire availableRowIndicesRange
+        tableView.reloadData(forRowIndexes: IndexSet(availableRowIndicesRange))
+      }
+    }
+
     let selectionIndices = episodeIdToIndexMap.compactMap { pair -> Int? in
-      return previousSelectedEpisodeIds.contains(pair.key) ? pair.value : nil
+      return selectedEpisodeIdsBeforeReload.contains(pair.key) ? pair.value : nil
     }
 
     tableView.selectRowIndexes(IndexSet(selectionIndices), byExtendingSelection: false)
+
+    // explicitly deselect since `tableViewSelectionDidChange:` won't call after `selectRowIndexes:byExtendingSelection:`
     if selectionIndices.isEmpty {
       viewController.selectEpisode(episode: nil)
-    }
-    tableView.scrollRowToVisible(tableView.selectedRow)
-  }
-
-  func reload(forEpisode episode: Episode) {
-    if let index = episodes.firstIndex(where: { $0.id == episode.id }) {
-      tableView.reloadData(forRowIndexes: IndexSet.init(integer: index), columnIndexes: IndexSet.init(integer: 0))
     }
   }
 

--- a/Doughnut/View Controllers/EpisodeViewController.swift
+++ b/Doughnut/View Controllers/EpisodeViewController.swift
@@ -205,6 +205,8 @@ final class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTabl
       if sortDirection == .desc {
         episodes.reverse()
       }
+    } else {
+      episodes = []
     }
 
     // Handle an empty table

--- a/Doughnut/View Controllers/PodcastViewController.swift
+++ b/Doughnut/View Controllers/PodcastViewController.swift
@@ -49,6 +49,7 @@ final class PodcastViewController: NSViewController, NSTableViewDelegate, NSTabl
   @IBOutlet var sortView: NSView!
   @IBOutlet var moreButton: NSButton!
   @IBOutlet var searchField: PodcastSearchField!
+  @IBOutlet var filterBarSeperator: NSBox!
 
   private var sortingMenuProvider: SortingMenuProvider {
     return SortingMenuProvider.Shared.podcasts
@@ -127,6 +128,13 @@ final class PodcastViewController: NSViewController, NSTableViewDelegate, NSTabl
       bottom: sortView.bounds.height,
       right: 0
     )
+
+    updateFilterBarSeperatorVisibility()
+  }
+
+  override func viewDidLayout() {
+    super.viewDidLayout()
+    updateFilterBarSeperatorVisibility()
   }
 
   func reloadPodcasts() {
@@ -234,6 +242,13 @@ final class PodcastViewController: NSViewController, NSTableViewDelegate, NSTabl
     if selectionIndices.isEmpty {
       viewController.selectPodcast(podcast: nil)
     }
+
+    updateFilterBarSeperatorVisibility()
+  }
+
+  private func updateFilterBarSeperatorVisibility() {
+    let hidesSeperator = tableView.frame.height <= tableScrollView.contentView.frame.height
+    filterBarSeperator.isHidden = hidesSeperator
   }
 
   func numberOfRows(in tableView: NSTableView) -> Int {


### PR DESCRIPTION
This PR fixes #58 and #63.

This PR adds necessary code to ensure list items are correctly updated when being filtered or sorted and improves the list reload performance.
Specifically, use `-[NSTableView enumerateAvailableRowViews:]` to find out visible columns and update accordingly, instead of reloading the entire list.

Currently `PodcastViewController` and `EpisodeViewController` share very similar logic regarding list reloads. Future efforts will be made to abstract these duplicate codes away.

This PR also includes a UI improvement that automatically hides the separator above the podcasts filter bar, to prevent merge conflicts.