### PR TITLE
Add PLCrashReporter to show troubleshoot and report options on crash.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Report a bug to help us improve Doughnut.
+title: ""
+labels: ""
+assignees: ""
+---
+
+<!-- Thank you for using Doughnut!
+  If you encounter crashes, use the dedicated template for crash reports:
+    * https://github.com/dyerc/Doughnut/issues/new?template=crash_report.md
+  -->
+
+## Steps to Reproduce:
+
+<!-- Please include full steps so that we can reproduce your problem. -->
+
+1. ... <!-- Describe steps to demonstrate bug -->
+2. ...
+3. ...
+
+**Expected results:** <!-- What did you expect to see? -->
+
+**Actual results:** <!-- What did you see? -->
+
+## Additional Information:
+
+<!-- Please complete the following information -->
+
+- Doughnut Version: [e.g. 1.1.1 (58)]
+- macOS Version: [e.g. 12.3 (21E230)]
+- Safari Version: [e.g. 15.4 (17613.1.17.1.6)]
+
+<!--
+  Consider also attaching screenshots and/or videos to better illustrate the issue.
+  You can drag to upload them directly on GitHub.
+  -->

--- a/.github/ISSUE_TEMPLATE/crash_report.md
+++ b/.github/ISSUE_TEMPLATE/crash_report.md
@@ -1,0 +1,37 @@
+---
+name: Crash Report
+about: Report a crash problem.
+title: "Crash: "
+labels: ""
+assignees: ""
+---
+
+<!-- Thank you for using Doughnut! -->
+
+## Steps to Reproduce:
+
+<!-- Please include full steps so that we can reproduce your problem. -->
+
+1. ... <!-- Describe steps to reproduce the crash -->
+2. ...
+3. ...
+
+**Crash Report:**
+
+<details>
+<summary>Crash Report</summary>
+<!-- Paste the crash report here, between the backticks -->
+```
+```
+</details>
+
+## Additional Information:
+
+<!-- Please complete the following information -->
+
+- Safari Version: [e.g. 15.4 (17613.1.17.1.6)]
+
+<!--
+  Consider also attaching screenshots and/or videos to better illustrate the issue.
+  You can drag to upload them directly on GitHub.
+  -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,11 @@
+---
+name: Feature Request
+about: Suggest a new feature for Doughnut.
+title: "FR: "
+labels: ""
+assignees: ""
+---
+
+<!-- Thank you for using Doughnut!
+  Please briefly describe what you would like Doughnut to be able to do.
+  -->

--- a/Doughnut.xcodeproj/project.pbxproj
+++ b/Doughnut.xcodeproj/project.pbxproj
@@ -12,13 +12,19 @@
 		5E0288D17E6858855545E02E /* Pods_DoughnutTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6BE29F62CFF7B122D5C39998 /* Pods_DoughnutTests.framework */; };
 		6B0233BD27B2CA6500500E28 /* ControlMenuProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0233BC27B2CA6500500E28 /* ControlMenuProvider.swift */; };
 		6B0605C52788627D00A8A91E /* NSMenu+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B0605C42788627D00A8A91E /* NSMenu+Extensions.swift */; };
+		6B193AA427A286B800DB1379 /* ModalSheetSegue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B193AA327A286B800DB1379 /* ModalSheetSegue.swift */; };
 		6B36624627CFB339008E1CA5 /* NSImage+Tint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B36624527CFB339008E1CA5 /* NSImage+Tint.swift */; };
 		6B3A75F8278F44F500F25578 /* NSView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B3A75F7278F44F500F25578 /* NSView+Extensions.swift */; };
+		6B5B39A327A448BF00234D82 /* NSButton+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5B39A227A448BF00234D82 /* NSButton+Extensions.swift */; };
 		6B94DF4C278968F500BCB149 /* NSTableView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B94DF4B278968F500BCB149 /* NSTableView+Extensions.swift */; };
 		6B96F45D27CE6F10001941BA /* PodcastSearchField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B96F45C27CE6F10001941BA /* PodcastSearchField.swift */; };
 		6B9C30BB27B5708300D462BE /* BaseTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9C30BA27B5708300D462BE /* BaseTableView.swift */; };
 		6B9E154727C9EA5F00C919D5 /* AppIcon_Big_Sur.icns in Resources */ = {isa = PBXBuildFile; fileRef = 6B9E154627C9EA5F00C919D5 /* AppIcon_Big_Sur.icns */; };
 		6BA21C4F279D690700CD3672 /* WindowController+Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA21C4E279D690700CD3672 /* WindowController+Toolbar.swift */; };
+		6BA21C57279D74D400CD3672 /* CrashReportViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA21C56279D74D400CD3672 /* CrashReportViewController.swift */; };
+		6BA21C59279D74DC00CD3672 /* CrashReport.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6BA21C58279D74DC00CD3672 /* CrashReport.storyboard */; };
+		6BA21C5C279D7A1100CD3672 /* CrashReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA21C5B279D7A1100CD3672 /* CrashReporter.swift */; };
+		6BB11F9C27A29B6E009CBAF8 /* CrashReportWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BB11F9B27A29B6E009CBAF8 /* CrashReportWindowController.swift */; };
 		6BB5771E278602B400DFF99F /* MainMenu.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 6BB5771C278602B400DFF99F /* MainMenu.storyboard */; };
 		6BC6395F27A6800500535897 /* Player+RemoteCommandCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC6395E27A6800500535897 /* Player+RemoteCommandCenter.swift */; };
 		6BC6396127A687E400535897 /* Player+NowPlayingInfoCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BC6396027A687E400535897 /* Player+NowPlayingInfoCenter.swift */; };
@@ -103,15 +109,21 @@
 		5E1DC050EEE121FD033C44DF /* Pods-Doughnut.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Doughnut.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Doughnut/Pods-Doughnut.debug.xcconfig"; sourceTree = "<group>"; };
 		6B0233BC27B2CA6500500E28 /* ControlMenuProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ControlMenuProvider.swift; sourceTree = "<group>"; };
 		6B0605C42788627D00A8A91E /* NSMenu+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMenu+Extensions.swift"; sourceTree = "<group>"; };
+		6B193AA327A286B800DB1379 /* ModalSheetSegue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModalSheetSegue.swift; sourceTree = "<group>"; };
 		6B36624527CFB339008E1CA5 /* NSImage+Tint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSImage+Tint.swift"; sourceTree = "<group>"; };
 		6B3A75F7278F44F500F25578 /* NSView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSView+Extensions.swift"; sourceTree = "<group>"; };
 		6B3ACC982773555700CF1EF1 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		6B5B39A227A448BF00234D82 /* NSButton+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSButton+Extensions.swift"; sourceTree = "<group>"; };
 		6B730B732767A90900FB5F84 /* Doughnut-Release.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Doughnut-Release.entitlements"; sourceTree = "<group>"; };
 		6B94DF4B278968F500BCB149 /* NSTableView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTableView+Extensions.swift"; sourceTree = "<group>"; };
 		6B96F45C27CE6F10001941BA /* PodcastSearchField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastSearchField.swift; sourceTree = "<group>"; };
 		6B9C30BA27B5708300D462BE /* BaseTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTableView.swift; sourceTree = "<group>"; };
 		6B9E154627C9EA5F00C919D5 /* AppIcon_Big_Sur.icns */ = {isa = PBXFileReference; lastKnownFileType = image.icns; path = AppIcon_Big_Sur.icns; sourceTree = "<group>"; };
 		6BA21C4E279D690700CD3672 /* WindowController+Toolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WindowController+Toolbar.swift"; sourceTree = "<group>"; };
+		6BA21C56279D74D400CD3672 /* CrashReportViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportViewController.swift; sourceTree = "<group>"; };
+		6BA21C58279D74DC00CD3672 /* CrashReport.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = CrashReport.storyboard; sourceTree = "<group>"; };
+		6BA21C5B279D7A1100CD3672 /* CrashReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReporter.swift; sourceTree = "<group>"; };
+		6BB11F9B27A29B6E009CBAF8 /* CrashReportWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashReportWindowController.swift; sourceTree = "<group>"; };
 		6BB5771D278602B400DFF99F /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainMenu.storyboard; sourceTree = "<group>"; };
 		6BC6395E27A6800500535897 /* Player+RemoteCommandCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Player+RemoteCommandCenter.swift"; sourceTree = "<group>"; };
 		6BC6396027A687E400535897 /* Player+NowPlayingInfoCenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Player+NowPlayingInfoCenter.swift"; sourceTree = "<group>"; };
@@ -221,6 +233,7 @@
 		6B0605BF2788624B00A8A91E /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				6B193AA327A286B800DB1379 /* ModalSheetSegue.swift */,
 				6B0605C22788626600A8A91E /* Extensions */,
 			);
 			path = Utilities;
@@ -238,12 +251,24 @@
 		6B0605C32788626F00A8A91E /* AppKit */ = {
 			isa = PBXGroup;
 			children = (
+				6B5B39A227A448BF00234D82 /* NSButton+Extensions.swift */,
 				6B0605C42788627D00A8A91E /* NSMenu+Extensions.swift */,
 				6B94DF4B278968F500BCB149 /* NSTableView+Extensions.swift */,
 				6B3A75F7278F44F500F25578 /* NSView+Extensions.swift */,
 				6B36624527CFB339008E1CA5 /* NSImage+Tint.swift */,
 			);
 			name = AppKit;
+			sourceTree = "<group>";
+		};
+		6BB11F9A27A292A3009CBAF8 /* CrashReport */ = {
+			isa = PBXGroup;
+			children = (
+				6BA21C5B279D7A1100CD3672 /* CrashReporter.swift */,
+				6BB11F9B27A29B6E009CBAF8 /* CrashReportWindowController.swift */,
+				6BA21C56279D74D400CD3672 /* CrashReportViewController.swift */,
+				6BA21C58279D74DC00CD3672 /* CrashReport.storyboard */,
+			);
+			path = CrashReport;
 			sourceTree = "<group>";
 		};
 		6BC6396227A68E0C00535897 /* CoreMedia */ = {
@@ -370,10 +395,11 @@
 				83FB4EB61F7BD996001CD842 /* Library */,
 				831EBAD427CC0DA500F212B4 /* Player */,
 				83235BF5200945D900BC356F /* Preference */,
-				6B0605BF2788624B00A8A91E /* Utilities */,
 				830B15991F7B97250086C121 /* Views */,
 				83667DEE1F76D1F300F1ABC0 /* View Controllers */,
 				839DBDA51FEEE872007610EF /* Windows */,
+				6BB11F9A27A292A3009CBAF8 /* CrashReport */,
+				6B0605BF2788624B00A8A91E /* Utilities */,
 				838257CD1F759F6F00DB4FD1 /* AppDelegate.swift */,
 				83BA22E21F994EA6006BF58A /* DoughnutApp.swift */,
 				6B0233BC27B2CA6500500E28 /* ControlMenuProvider.swift */,
@@ -606,6 +632,7 @@
 			files = (
 				838257D21F759F6F00DB4FD1 /* Assets.xcassets in Resources */,
 				6BB5771E278602B400DFF99F /* MainMenu.storyboard in Resources */,
+				6BA21C59279D74DC00CD3672 /* CrashReport.storyboard in Resources */,
 				6BF126D12780727100D840A4 /* EpisodeInfo.storyboard in Resources */,
 				831EBADA27CC120000F212B4 /* Credits.rtf in Resources */,
 				6B9E154727C9EA5F00C919D5 /* AppIcon_Big_Sur.icns in Resources */,
@@ -783,8 +810,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				8343426A1F802C1400913C0B /* EpisodeFilterViewController.swift in Sources */,
+				6B193AA427A286B800DB1379 /* ModalSheetSegue.swift in Sources */,
 				839A32811FF9831B002D2023 /* ShowEpisodeWindow.swift in Sources */,
 				8389709C20069D720094795D /* SortingMenuProvider.swift in Sources */,
+				6BA21C5C279D7A1100CD3672 /* CrashReporter.swift in Sources */,
 				83E95A5E1FFBCA3C00C6AABF /* Storage.swift in Sources */,
 				8341B83B1F7BEB0500B50A5D /* Migrations.swift in Sources */,
 				6B9C30BB27B5708300D462BE /* BaseTableView.swift in Sources */,
@@ -793,17 +822,20 @@
 				6BC6395F27A6800500535897 /* Player+RemoteCommandCenter.swift in Sources */,
 				83D9710C1F812E910091822A /* PlayerView.swift in Sources */,
 				83235C042009473200BC356F /* PrefLibraryViewController.swift in Sources */,
+				6B5B39A327A448BF00234D82 /* NSButton+Extensions.swift in Sources */,
 				6B0605C52788627D00A8A91E /* NSMenu+Extensions.swift in Sources */,
 				6BA21C4F279D690700CD3672 /* WindowController+Toolbar.swift in Sources */,
 				839DBDA41FEEE658007610EF /* ShowPodcastWindow.swift in Sources */,
 				6B0233BD27B2CA6500500E28 /* ControlMenuProvider.swift in Sources */,
 				83D9710A1F812B270091822A /* Player.swift in Sources */,
+				6BA21C57279D74D400CD3672 /* CrashReportViewController.swift in Sources */,
 				837D52C01F8E683200C17514 /* DownloadCellView.swift in Sources */,
 				83DB16E11F93FB460062B266 /* SubscribeViewController.swift in Sources */,
 				83504DD61FFC377700375BA0 /* EpisodeDownloadTask.swift in Sources */,
 				83BA22E31F994EA6006BF58A /* DoughnutApp.swift in Sources */,
 				832A04341F76EBDC00C92D25 /* WindowController.swift in Sources */,
 				6B94DF4C278968F500BCB149 /* NSTableView+Extensions.swift in Sources */,
+				6BB11F9C27A29B6E009CBAF8 /* CrashReportWindowController.swift in Sources */,
 				830B159B1F7B97910086C121 /* PodcastCellView.swift in Sources */,
 				83235C072009473500BC356F /* PrefPlaybackViewController.swift in Sources */,
 				830E99BD1FF50DD000B728BE /* ActivityIndicator.swift in Sources */,

--- a/Doughnut/Base.lproj/MainMenu.storyboard
+++ b/Doughnut/Base.lproj/MainMenu.storyboard
@@ -442,6 +442,19 @@ CA
                                     </items>
                                 </menu>
                             </menuItem>
+                            <menuItem title="Debug" id="Hwi-3h-UUh">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Debug" identifier="NSDoughnutMainMenuDebug" id="G8T-am-4h4">
+                                    <items>
+                                        <menuItem title="Force Crash" id="3HW-XB-yuZ">
+                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                            <connections>
+                                                <action selector="forceCrash:" target="Voe-Tx-rLC" id="Rdo-Iq-6uW"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
                             <menuItem title="Help" id="wpr-3q-Mcd">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">

--- a/Doughnut/CrashReport/CrashReport.storyboard
+++ b/Doughnut/CrashReport/CrashReport.storyboard
@@ -1,0 +1,286 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" initialViewController="8cc-hm-m1Z">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Window Controller-->
+        <scene sceneID="drv-Wb-Jzs">
+            <objects>
+                <windowController id="8cc-hm-m1Z" customClass="CrashReportWindowController" customModule="Doughnut" customModuleProvider="target" sceneMemberID="viewController">
+                    <window key="window" title="Doughnut Crash Report" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="nOY-PN-AqB" customClass="NSPanel">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="270" y="342" width="640" height="480"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1800" height="1125"/>
+                        <value key="minSize" type="size" width="640" height="480"/>
+                        <view key="contentView" id="yo5-M5-gYA">
+                            <rect key="frame" x="0.0" y="0.0" width="640" height="480"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </view>
+                        <connections>
+                            <outlet property="delegate" destination="8cc-hm-m1Z" id="Kij-wy-1oe"/>
+                        </connections>
+                    </window>
+                    <connections>
+                        <segue destination="Se8-Fb-pzw" kind="relationship" relationship="window.shadowedContentViewController" id="3f7-j7-dWY"/>
+                    </connections>
+                </windowController>
+                <customObject id="9TN-pI-xQR" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4" y="57"/>
+        </scene>
+        <!--Crash Report View Controller-->
+        <scene sceneID="iPk-6L-7xH">
+            <objects>
+                <viewController id="Se8-Fb-pzw" customClass="CrashReportViewController" customModule="Doughnut" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="G5u-Xk-445">
+                        <rect key="frame" x="0.0" y="0.0" width="779" height="486"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Efq-Q8-6xh">
+                                <rect key="frame" x="18" y="445" width="743" height="21"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Doughnut Has Crashed Unexpectedly" id="rnr-Rf-1oe">
+                                    <font key="font" textStyle="title2" name=".SFNS-Regular"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Gs4-fu-8WS">
+                                <rect key="frame" x="18" y="417" width="743" height="16"/>
+                                <textFieldCell key="cell" title="To help us examine and fix this problem, click Send Crash Log and paste the following content to open an issue on GitHub." id="ESE-XB-ZG0">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TeV-Wd-Cpf">
+                                <rect key="frame" x="20" y="52" width="739" height="353"/>
+                                <clipView key="contentView" drawsBackground="NO" id="zg8-wK-oUp">
+                                    <rect key="frame" x="0.0" y="0.0" width="739" height="353"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <textView editable="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" spellingCorrection="YES" smartInsertDelete="YES" id="a5H-7D-j2N">
+                                            <rect key="frame" x="0.0" y="0.0" width="739" height="353"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            <size key="minSize" width="739" height="353"/>
+                                            <size key="maxSize" width="780" height="10000000"/>
+                                            <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                        </textView>
+                                    </subviews>
+                                </clipView>
+                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="QzS-ZQ-3E7">
+                                    <rect key="frame" x="-100" y="-100" width="240" height="16"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="kV0-fd-Pl7">
+                                    <rect key="frame" x="723" y="0.0" width="16" height="353"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                            </scrollView>
+                            <stackView distribution="fill" orientation="horizontal" alignment="centerY" spacing="12" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="83z-Py-J5q">
+                                <rect key="frame" x="563" y="20" width="196" height="20"/>
+                                <subviews>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SIn-03-DAo">
+                                        <rect key="frame" x="-7" y="-7" width="81" height="32"/>
+                                        <buttonCell key="cell" type="push" title="Dismiss" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ZKa-ZE-1Re">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="dismissCrashReport:" target="Se8-Fb-pzw" id="Np0-d5-U7X"/>
+                                        </connections>
+                                    </button>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nQT-9g-W9Y">
+                                        <rect key="frame" x="72" y="-7" width="131" height="32"/>
+                                        <buttonCell key="cell" type="push" title="Send Crash Log" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="6Hb-mZ-XNd">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="sendCrashLog:" target="Se8-Fb-pzw" id="5Sx-IH-z5w"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <visibilityPriorities>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                </visibilityPriorities>
+                                <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                </customSpacing>
+                            </stackView>
+                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YnD-fx-Hn6">
+                                <rect key="frame" x="13" y="13" width="143" height="32"/>
+                                <buttonCell key="cell" type="push" title="Troubleshooting…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="bQb-1e-Sdp">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <segue destination="0kF-kc-fa8" kind="custom" identifier="" customClass="ModalSheetStoryboardSegue" customModule="Doughnut" customModuleProvider="target" id="dwS-Wt-t04"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="TeV-Wd-Cpf" firstAttribute="leading" secondItem="G5u-Xk-445" secondAttribute="leading" constant="20" symbolic="YES" id="CaT-4W-d7B"/>
+                            <constraint firstItem="Efq-Q8-6xh" firstAttribute="leading" secondItem="G5u-Xk-445" secondAttribute="leading" constant="20" symbolic="YES" id="CpE-Q6-na8"/>
+                            <constraint firstItem="Gs4-fu-8WS" firstAttribute="top" secondItem="Efq-Q8-6xh" secondAttribute="bottom" constant="12" id="D3A-PF-foa"/>
+                            <constraint firstAttribute="bottom" secondItem="83z-Py-J5q" secondAttribute="bottom" constant="20" symbolic="YES" id="F29-2E-xOe"/>
+                            <constraint firstAttribute="trailing" secondItem="TeV-Wd-Cpf" secondAttribute="trailing" constant="20" symbolic="YES" id="Q83-9B-J1d"/>
+                            <constraint firstItem="Efq-Q8-6xh" firstAttribute="top" secondItem="G5u-Xk-445" secondAttribute="top" constant="20" symbolic="YES" id="TZV-OP-0s5"/>
+                            <constraint firstAttribute="trailing" secondItem="Gs4-fu-8WS" secondAttribute="trailing" constant="20" symbolic="YES" id="VJF-Ui-Moa"/>
+                            <constraint firstAttribute="trailing" secondItem="Efq-Q8-6xh" secondAttribute="trailing" constant="20" symbolic="YES" id="YDV-fp-oyc"/>
+                            <constraint firstItem="TeV-Wd-Cpf" firstAttribute="top" secondItem="Gs4-fu-8WS" secondAttribute="bottom" constant="12" id="YoC-Gy-sdS"/>
+                            <constraint firstItem="83z-Py-J5q" firstAttribute="top" secondItem="TeV-Wd-Cpf" secondAttribute="bottom" constant="12" id="dlU-0q-449"/>
+                            <constraint firstAttribute="trailing" secondItem="83z-Py-J5q" secondAttribute="trailing" constant="20" symbolic="YES" id="hi1-vY-4KU"/>
+                            <constraint firstAttribute="bottom" secondItem="YnD-fx-Hn6" secondAttribute="bottom" constant="20" id="iZU-8o-ofF"/>
+                            <constraint firstItem="Gs4-fu-8WS" firstAttribute="leading" secondItem="G5u-Xk-445" secondAttribute="leading" constant="20" symbolic="YES" id="jkQ-Gv-ZZp"/>
+                            <constraint firstItem="YnD-fx-Hn6" firstAttribute="leading" secondItem="G5u-Xk-445" secondAttribute="leading" constant="20" id="lCx-wN-NzT"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="contentTextView" destination="a5H-7D-j2N" id="hWr-cH-rFN"/>
+                    </connections>
+                </viewController>
+                <customObject id="170-QR-noU" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5" y="669"/>
+        </scene>
+        <!--Window Controller-->
+        <scene sceneID="0Ia-JB-1GR">
+            <objects>
+                <windowController id="0kF-kc-fa8" sceneMemberID="viewController">
+                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="hLw-Gh-USl">
+                        <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+                        <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+                        <rect key="contentRect" x="270" y="342" width="480" height="270"/>
+                        <rect key="screenRect" x="0.0" y="0.0" width="1800" height="1125"/>
+                        <view key="contentView" id="QYY-ET-f2H">
+                            <rect key="frame" x="0.0" y="0.0" width="480" height="270"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </view>
+                        <connections>
+                            <outlet property="delegate" destination="0kF-kc-fa8" id="ERC-7G-uYJ"/>
+                        </connections>
+                    </window>
+                    <connections>
+                        <segue destination="FN4-GX-cgf" kind="relationship" relationship="window.shadowedContentViewController" id="VVM-Tz-YQE"/>
+                    </connections>
+                </windowController>
+                <customObject id="SRm-p7-tFP" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="776" y="231"/>
+        </scene>
+        <!--Troubleshooting View Controller-->
+        <scene sceneID="KSo-ES-n8v">
+            <objects>
+                <viewController id="FN4-GX-cgf" customClass="TroubleshootingViewController" customModule="Doughnut" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" id="sLU-PQ-FTB">
+                        <rect key="frame" x="0.0" y="0.0" width="480" height="236"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                        <subviews>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="6pz-zE-k1R">
+                                <rect key="frame" x="0.0" y="0.0" width="480" height="236"/>
+                                <subviews>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2Xc-QN-jhy">
+                                        <rect key="frame" x="18" y="147" width="444" height="32"/>
+                                        <textFieldCell key="cell" title="If the problem continues to persist, please try the following troubleshooting options." id="oZv-PN-5YO">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EbZ-p9-8ZM">
+                                        <rect key="frame" x="18" y="195" width="128" height="21"/>
+                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Troubleshooting" id="ec5-Tt-sKB">
+                                            <font key="font" textStyle="title2" name=".SFNS-Regular"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zpR-Dz-HLg">
+                                        <rect key="frame" x="13" y="104" width="262" height="32"/>
+                                        <buttonCell key="cell" type="push" title="Restore Preferences to their Default…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Wgu-Ra-wRX">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="troubleshootingResetPreferences:" target="FN4-GX-cgf" id="aei-yJ-bnJ"/>
+                                        </connections>
+                                    </button>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EFb-gG-pyk">
+                                        <rect key="frame" x="13" y="72" width="182" height="32"/>
+                                        <buttonCell key="cell" type="push" title="Locate Another Library…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="gA7-4R-Z9K">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="troubleshootingRelocateLibrary:" target="FN4-GX-cgf" id="gM0-85-TyV"/>
+                                        </connections>
+                                    </button>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HIn-0b-WbW">
+                                        <rect key="frame" x="18" y="56" width="408" height="15"/>
+                                        <textFieldCell key="cell" lineBreakMode="clipping" title="A new library will be created if no library files exist at the selected path." id="daa-9a-XZP">
+                                            <font key="font" textStyle="callout" name=".SFNS-Regular"/>
+                                            <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Ed-rs-LIW">
+                                        <rect key="frame" x="401" y="13" width="66" height="32"/>
+                                        <buttonCell key="cell" type="push" title="Done" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="QRk-Vh-Jyf">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                            <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="dismissController:" target="FN4-GX-cgf" id="u3P-xH-83d"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="8Ed-rs-LIW" secondAttribute="trailing" constant="20" id="5x4-U7-LLt"/>
+                                    <constraint firstItem="EbZ-p9-8ZM" firstAttribute="top" secondItem="6pz-zE-k1R" secondAttribute="top" constant="20" id="9GL-1H-Yxr"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="HIn-0b-WbW" secondAttribute="trailing" id="9gf-eI-AqF"/>
+                                    <constraint firstItem="2Xc-QN-jhy" firstAttribute="top" secondItem="EbZ-p9-8ZM" secondAttribute="bottom" constant="16" id="BGD-To-GDo"/>
+                                    <constraint firstAttribute="trailing" secondItem="2Xc-QN-jhy" secondAttribute="trailing" constant="20" id="C5h-xI-D0P"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="EbZ-p9-8ZM" secondAttribute="trailing" id="Eeh-43-jdv"/>
+                                    <constraint firstItem="HIn-0b-WbW" firstAttribute="leading" secondItem="EFb-gG-pyk" secondAttribute="leading" id="FIP-CY-t5B"/>
+                                    <constraint firstItem="8Ed-rs-LIW" firstAttribute="top" secondItem="HIn-0b-WbW" secondAttribute="bottom" constant="16" id="GlH-P5-Qdt"/>
+                                    <constraint firstItem="zpR-Dz-HLg" firstAttribute="leading" secondItem="6pz-zE-k1R" secondAttribute="leading" constant="20" id="Jaw-w2-aoL"/>
+                                    <constraint firstAttribute="bottom" secondItem="8Ed-rs-LIW" secondAttribute="bottom" constant="20" id="LVF-9o-GiM"/>
+                                    <constraint firstItem="zpR-Dz-HLg" firstAttribute="top" secondItem="2Xc-QN-jhy" secondAttribute="bottom" constant="16" id="SJr-r0-O9W"/>
+                                    <constraint firstItem="EFb-gG-pyk" firstAttribute="leading" secondItem="6pz-zE-k1R" secondAttribute="leading" constant="20" id="h4y-YY-2ls"/>
+                                    <constraint firstItem="EbZ-p9-8ZM" firstAttribute="leading" secondItem="6pz-zE-k1R" secondAttribute="leading" constant="20" id="jm0-kX-IrY"/>
+                                    <constraint firstItem="EFb-gG-pyk" firstAttribute="top" secondItem="zpR-Dz-HLg" secondAttribute="bottom" constant="12" id="onx-3A-iYr"/>
+                                    <constraint firstAttribute="width" constant="480" id="rzI-0h-gWa"/>
+                                    <constraint firstItem="2Xc-QN-jhy" firstAttribute="leading" secondItem="6pz-zE-k1R" secondAttribute="leading" constant="20" id="sWr-mF-4gL"/>
+                                    <constraint firstItem="HIn-0b-WbW" firstAttribute="top" secondItem="EFb-gG-pyk" secondAttribute="bottom" constant="8" id="ziN-Tk-j3y"/>
+                                </constraints>
+                            </customView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="6pz-zE-k1R" secondAttribute="bottom" id="7Og-ho-rTd"/>
+                            <constraint firstItem="6pz-zE-k1R" firstAttribute="top" secondItem="sLU-PQ-FTB" secondAttribute="top" id="Pne-3O-Wbt"/>
+                            <constraint firstAttribute="trailing" secondItem="6pz-zE-k1R" secondAttribute="trailing" id="cdy-7X-B8o"/>
+                            <constraint firstItem="6pz-zE-k1R" firstAttribute="leading" secondItem="sLU-PQ-FTB" secondAttribute="leading" id="nWg-oW-vJ7"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="relocateLibraryButton" destination="EFb-gG-pyk" id="mrd-Oc-n9Y"/>
+                        <outlet property="resetPreferencesButton" destination="zpR-Dz-HLg" id="scv-IC-akn"/>
+                    </connections>
+                </viewController>
+                <customObject id="sDl-4Z-sEt" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="776" y="612"/>
+        </scene>
+    </scenes>
+</document>

--- a/Doughnut/CrashReport/CrashReportViewController.swift
+++ b/Doughnut/CrashReport/CrashReportViewController.swift
@@ -1,0 +1,124 @@
+/*
+ * Doughnut Podcast Client
+ * Copyright (C) 2017 - 2022 Chris Dyer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import AppKit
+
+final class CrashReportViewController: NSViewController {
+
+  @IBOutlet private weak var contentTextView: NSTextView!
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    contentTextView.font = NSFont.userFixedPitchFont(ofSize: 12)
+    contentTextView.textContainerInset = NSSize(width: 4, height: 4)
+  }
+
+  override func viewWillAppear() {
+    super.viewWillAppear()
+
+    view.window?.level = .modalPanel
+    view.window?.isReleasedWhenClosed = true
+    view.window?.center()
+  }
+
+  func setCrashContent(_ content: String) {
+    contentTextView.string = content
+  }
+
+  @IBAction private func sendCrashLog(_ sender: Any) {
+    if let crashReportURLStr = Bundle.main.infoDictionary?["DoughnutCrashReportURL"] as? String,
+       let crashReportURL = URL(string: crashReportURLStr)
+    {
+      NSWorkspace.shared.open(crashReportURL)
+    }
+  }
+
+  @IBAction private func dismissCrashReport(_ sender: Any) {
+    view.window?.windowController?.close()
+  }
+
+}
+
+final class TroubleshootingViewController: NSViewController {
+
+  @IBOutlet weak var resetPreferencesButton: NSButton!
+  @IBOutlet weak var relocateLibraryButton: NSButton!
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    resetPreferencesButton.setTitleColor(NSColor.systemRed)
+  }
+
+  @IBAction private func troubleshootingResetPreferences(_ sender: Any) {
+    let alert = NSAlert()
+    alert.addButton(withTitle: "Cancel")
+    alert.addButton(withTitle: "Confirm")
+    alert.messageText = "Are you sure you want to restore all preferences to their default settings?"
+    alert.informativeText = "You can’t undo this action."
+
+    guard alert.runModal() == .alertSecondButtonReturn else {
+      return
+    }
+
+    dismiss(self)
+
+    UserDefaults.standard.removePersistentDomain(forName: Bundle.main.bundleIdentifier!)
+    UserDefaults.standard.synchronize()
+
+    promptRestart()
+  }
+
+  @IBAction private func troubleshootingRelocateLibrary(_ sender: Any) {
+    let panel = NSOpenPanel()
+    panel.canChooseDirectories = true
+    panel.canChooseFiles = false
+    panel.allowsMultipleSelection = false
+
+    guard panel.runModal() == .OK, let url = panel.url else {
+      return
+    }
+
+    dismiss(self)
+
+    Preference.set(url, for: Preference.Key.libraryPath)
+
+    promptRestart()
+  }
+
+  private func promptRestart() {
+    let alert = NSAlert()
+    alert.addButton(withTitle: "OK")
+    alert.messageText = "Doughnut Will Restart"
+    alert.informativeText = "Doughnut will restart to apply these changes."
+
+    alert.runModal()
+
+    let task = Process()
+
+    var args = [String]()
+    args.append("-c")
+    args.append("sleep 0.2; open \"\(Bundle.main.bundlePath)\"")
+
+    task.launchPath = "/bin/sh"
+    task.arguments = args
+    task.launch()
+    NSApp.terminate(self)
+  }
+
+}

--- a/Doughnut/CrashReport/CrashReportWindowController.swift
+++ b/Doughnut/CrashReport/CrashReportWindowController.swift
@@ -1,0 +1,39 @@
+/*
+ * Doughnut Podcast Client
+ * Copyright (C) 2017 - 2022 Chris Dyer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import AppKit
+
+final class CrashReportWindowController: NSWindowController, NSWindowDelegate {
+
+  private var crashReportViewController: CrashReportViewController {
+    return contentViewController as! CrashReportViewController
+  }
+
+  static func instantiateFromMainStoryboard() -> Self? {
+    return NSStoryboard(name: "CrashReport", bundle: nil).instantiateInitialController() as? Self
+  }
+
+  func setCrashContent(_ content: String) {
+    crashReportViewController.setCrashContent(content)
+  }
+
+  func windowWillClose(_ notification: Notification) {
+    NSApp.stopModal(withCode: .OK)
+  }
+
+}

--- a/Doughnut/CrashReport/CrashReporter.swift
+++ b/Doughnut/CrashReport/CrashReporter.swift
@@ -1,0 +1,84 @@
+/*
+ * Doughnut Podcast Client
+ * Copyright (C) 2017 - 2022 Chris Dyer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+import CrashReporter
+
+final class CrashReporter {
+
+  static var shared: CrashReporter {
+    return sharedInstance
+  }
+
+  private static var sharedInstance = CrashReporter()
+
+  private var plCrashReporter: PLCrashReporter!
+
+  private init() {
+    setup()
+  }
+
+  private func setup() {
+    let config = PLCrashReporterConfig.defaultConfiguration()
+    guard let plCrashReporter = PLCrashReporter(configuration: config) else {
+      print("CrashReporter: could not create an instance of PLCrashReporter")
+      return
+    }
+    self.plCrashReporter = plCrashReporter
+    // enable the PLCrashReporter
+    do {
+      try plCrashReporter.enableAndReturnError()
+    } catch {
+      print("CrashReporter: failed to enable PLCrashReporter: \(error)")
+    }
+  }
+
+  func getPendingCrashReport() -> String? {
+    guard plCrashReporter.hasPendingCrashReport() else {
+      return nil
+    }
+
+    defer {
+      // purge the report
+      plCrashReporter.purgePendingCrashReport()
+    }
+
+    do {
+      let data = try plCrashReporter.loadPendingCrashReportDataAndReturnError()
+
+      // retrieve crash reporter data
+      let report = try PLCrashReport(data: data)
+
+      if let text = PLCrashReportTextFormatter.stringValue(for: report, with: PLCrashReportTextFormatiOS) {
+        return text
+      } else {
+        print("CrashReporter: can't convert the report to text")
+      }
+    } catch {
+      print("CrashReporter failed to load and parse crash report: \(error)")
+    }
+
+    return nil
+  }
+
+  func forceCrash() {
+    fatalError("Force crashd in \(#function)")
+  }
+
+}

--- a/Doughnut/Info.plist
+++ b/Doughnut/Info.plist
@@ -20,6 +20,8 @@
 	<string>2.0.0.beta1</string>
 	<key>CFBundleVersion</key>
 	<string>84</string>
+	<key>DoughnutCrashReportURL</key>
+	<string>https://github.com/dyerc/Doughnut/issues/new?template=crash_report.md</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.news</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Doughnut/Preference/Preference.swift
+++ b/Doughnut/Preference/Preference.swift
@@ -50,6 +50,9 @@ class Preference {
     static let skipForwardDuration = Key("skipForwardDuration")
     static let skipBackDuration = Key("skipBackDuration")
     static let replayAfterPause = Key("replayAfterPause")
+
+    // Debuging
+    static let debugMenuEnabled = Key("debugMenuEnabled")
   }
 
   enum AppIconStyle: Int {

--- a/Doughnut/Utilities/ModalSheetSegue.swift
+++ b/Doughnut/Utilities/ModalSheetSegue.swift
@@ -1,0 +1,43 @@
+/*
+ * Doughnut Podcast Client
+ * Copyright (C) 2017 - 2022 Chris Dyer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import AppKit
+
+final class ModalSheetStoryboardSegue: NSStoryboardSegue {
+
+  override func perform() {
+    let resolveViewController: (Any) -> NSViewController? = { controller in
+      if let controller = controller as? NSViewController {
+        return controller
+      } else if let controller = controller as? NSWindowController {
+        return controller.contentViewController
+      }
+      return nil
+    }
+
+    guard
+      let sourceViewController = resolveViewController(sourceController),
+      let destinationViewController = resolveViewController(destinationController)
+    else {
+      assert(false, "ModalSheetStoryboardSegue: failed to resolve viewControllers in \(#function)")
+      return
+    }
+    sourceViewController.presentAsSheet(destinationViewController)
+  }
+
+}

--- a/Doughnut/Utilities/NSButton+Extensions.swift
+++ b/Doughnut/Utilities/NSButton+Extensions.swift
@@ -1,0 +1,33 @@
+/*
+ * Doughnut Podcast Client
+ * Copyright (C) 2017 - 2022 Chris Dyer
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import AppKit
+
+extension NSButton {
+
+  func setTitleColor(_ color: NSColor) {
+    let coloredTitle = NSMutableAttributedString(
+      string: title,
+      attributes: [
+        .foregroundColor: color,
+      ]
+    )
+    attributedTitle = coloredTitle
+  }
+
+}

--- a/Doughnut/WindowController.swift
+++ b/Doughnut/WindowController.swift
@@ -38,6 +38,7 @@ final class WindowController: NSWindowController, NSWindowDelegate, NSTextFieldD
     super.windowDidLoad()
 
     window?.titleVisibility = .hidden
+    window?.center()
 
     if #available(macOS 11.0, *) {
       window?.toolbarStyle = .unified

--- a/Podfile
+++ b/Podfile
@@ -10,6 +10,7 @@ target 'Doughnut' do
   pod 'FeedKit', '9.1.2'
   pod 'MASPreferences', :git => 'https://github.com/shpakovski/MASPreferences.git', :commit => '135869c'
   pod 'Sparkle', '1.27.1'
+  pod 'PLCrashReporter', '1.10.1'
 end
 
 target 'DoughnutTests' do

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,18 +4,21 @@ PODS:
     - GRDB.swift/standard (= 5.17.0)
   - GRDB.swift/standard (5.17.0)
   - MASPreferences (1.3)
+  - PLCrashReporter (1.10.1)
   - Sparkle (1.27.1)
 
 DEPENDENCIES:
   - FeedKit (= 9.1.2)
   - GRDB.swift (= 5.17.0)
   - MASPreferences (from `https://github.com/shpakovski/MASPreferences.git`, commit `135869c`)
+  - PLCrashReporter (= 1.10.1)
   - Sparkle (= 1.27.1)
 
 SPEC REPOS:
   trunk:
     - FeedKit
     - GRDB.swift
+    - PLCrashReporter
     - Sparkle
 
 EXTERNAL SOURCES:
@@ -32,8 +35,9 @@ SPEC CHECKSUMS:
   FeedKit: 71653273ab08e618cd6fd1301ca08fc02dca6a9e
   GRDB.swift: 1c8a479b2723beab39ed8609fe25513483a0f282
   MASPreferences: f5cf4c3f91714fcb4e1ce21b7002880353fe7c5e
+  PLCrashReporter: b30195e509f07299ea277d1997b3a39449d05698
   Sparkle: 23f98b268284c8c03e6228230fc8f1807ef041d5
 
-PODFILE CHECKSUM: 0b464282dec6fd43ebd277f4b7c863210e357597
+PODFILE CHECKSUM: eda8b35c82199a93c745135e96097d7a487d5530
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
This PR adds integration with [PLCrashReporter](https://github.com/microsoft/plcrashreporter).

A crash report window will show on the next launch after a crash to guide users to perform troubleshooting options and report it.
<img width="891" alt="Screen Shot 2022-03-12 at 13 02 17" src="https://user-images.githubusercontent.com/8158163/158004570-ac628b9f-a1a0-46fb-87ac-2736fd1094ce.png">

The "Report" button will guide the user directly to the GitHub issue template to open an issue.

Rather than upload crashes automatically to a dedicated server or integrate with an existing crash monitoring service, this approach ensures Doughnut untied with any first or third-party services and gives users their own choice of whether or not to submit crash reports.