### PR TITLE
Implement async podcast saving methods that don’t block the task queue.

### DIFF
--- a/Doughnut/Preference/Preference.swift
+++ b/Doughnut/Preference/Preference.swift
@@ -170,6 +170,7 @@ class Preference {
   static func libraryPath() -> URL {
     if testEnv() {
       let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("Doughtnut_test")
+      try? FileManager.default.removeItem(at: url)
       createLibraryIfNotExists(url)
       return url
     } else {

--- a/Doughnut/View Controllers/EpisodeViewController.swift
+++ b/Doughnut/View Controllers/EpisodeViewController.swift
@@ -294,7 +294,7 @@ final class EpisodeViewController: NSViewController, NSTableViewDelegate, NSTabl
 
       Episode.fromFile(podcast: podcast, url: sourceURL, copyToLibrary: moveToLibrary, completion: { episode in
         podcast.episodes.append(episode)
-        Library.global.save(podcast: podcast)
+        Library.global.update(podcast: podcast)
       })
     }
 

--- a/Doughnut/View Controllers/PodcastViewController.swift
+++ b/Doughnut/View Controllers/PodcastViewController.swift
@@ -294,7 +294,7 @@ final class PodcastViewController: NSViewController, NSTableViewDelegate, NSTabl
       viewController.libraryUpdatedPodcast(podcast: podcast)
 
       // Commit changes to library
-      Library.global.save(podcast: podcast)
+      Library.global.update(podcast: podcast)
     }
   }
 
@@ -310,7 +310,7 @@ final class PodcastViewController: NSViewController, NSTableViewDelegate, NSTabl
       viewController.libraryUpdatedPodcast(podcast: podcast)
 
       // Commit changes to library
-      Library.global.save(podcast: podcast)
+      Library.global.update(podcast: podcast)
     }
   }
 

--- a/Doughnut/Windows/ShowPodcastWindow.swift
+++ b/Doughnut/Windows/ShowPodcastWindow.swift
@@ -194,9 +194,11 @@ class ShowPodcastViewController: NSViewController {
       commitChanges(podcast)
 
       if Self.validate(forPodcast: podcast) {
-        Library.global.save(podcast: podcast)
-        NSApp.stopModal(withCode: .OK)
-        view.window?.close()
+        Library.global.update(podcast: podcast) { [weak self] _ in
+          // TODO: prompt for error on failure
+          NSApp.stopModal(withCode: .OK)
+          self?.view.window?.close()
+        }
       }
     } else {
       // Create new podcast

--- a/DoughnutTests/LibraryTests/LibraryTestsWithSubscription.swift
+++ b/DoughnutTests/LibraryTests/LibraryTestsWithSubscription.swift
@@ -169,7 +169,7 @@ class LibraryTestsWithSubscription: LibraryTestCase {
     spy.updatedPodcastExpectation = self.expectation(description: "Library updated podcast")
 
     podcast.title = "This is the new title"
-    Library.global.save(podcast: podcast)
+    Library.global.update(podcast: podcast)
 
     self.waitForExpectations(timeout: 10) { _ in
       XCTAssertEqual(Library.global.podcasts.first?.title, "This is the new title")


### PR DESCRIPTION
This PR fixes #69.

The issue appears when refresh a long list of podcasts. The feed parsing call blocks the serial `taskQueue` due to network loads and all database operations piled onto the back of the queue have nearly no chance to execute, even though podcasts have been updated in memory.

<img width="661" alt="Screen Shot 2022-03-19 at 11 37 30" src="https://user-images.githubusercontent.com/8158163/159105402-df1e9605-bc38-4b36-ac56-e9b4b4d3d264.png">

This PR solves this specific problem by removing `taskQueue.async` call on database operations related to podcast, use async calls for both inserting and updating and return `Result` as callback.