### PR TITLE
Fix: sidebar images dimmed out when window not active on macOS 13 beta.

### DIFF
--- a/Doughnut/Base.lproj/Main.storyboard
+++ b/Doughnut/Base.lproj/Main.storyboard
@@ -421,7 +421,6 @@ Gw
                                                                 <outlet property="artwork" destination="WuW-3B-toC" id="Lus-7p-rwp"/>
                                                                 <outlet property="author" destination="AHY-Ts-qj2" id="YF2-bT-zJ3"/>
                                                                 <outlet property="episodeCount" destination="Pkl-Lr-qxa" id="A5q-iE-0c5"/>
-                                                                <outlet property="imageView" destination="WuW-3B-toC" id="qce-6g-Mlb"/>
                                                                 <outlet property="podcastUnplayedCount" destination="qSa-lt-Xvr" id="eZs-zW-Ttc"/>
                                                                 <outlet property="podcastUnplayedCountTrailingConstraint" destination="1o0-ea-oPQ" id="sIJ-Rk-cs4"/>
                                                                 <outlet property="title" destination="yFZ-qJ-tU0" id="WAu-w6-NGc"/>

--- a/Doughnut/View Controllers/PodcastViewController.swift
+++ b/Doughnut/View Controllers/PodcastViewController.swift
@@ -267,9 +267,9 @@ final class PodcastViewController: NSViewController, NSTableViewDelegate, NSTabl
     result.author.stringValue = podcast.author ?? ""
 
     if podcast.image != nil && podcast.image!.isValid {
-      result.imageView?.image = podcast.image
+      result.artwork.image = podcast.image
     } else {
-      result.imageView?.image = NSImage(named: "PodcastPlaceholder")
+      result.artwork.image = NSImage(named: "PodcastPlaceholder")
     }
 
     result.episodeCount.stringValue = "\(podcast.episodes.count) episodes"


### PR DESCRIPTION
This PR fixes an issue on macOS 13 beta that podcast images on the sidebar are dimmed out when the main window is inactive.