### PR TITLE
Implement custom User-Agent for media playback

### DIFF
--- a/Doughnut/Player/Player.swift
+++ b/Doughnut/Player/Player.swift
@@ -77,6 +77,8 @@ final class Player: NSObject {
 
   private var periodicTimeObservers = [Any]()
 
+  private let userAgent: String = buildUserAgent()
+
   override init() {
     super.init()
     setupRemoteCommands()
@@ -105,7 +107,12 @@ final class Player: NSObject {
       guard let url = URL(string: enclosureUrl) else { return }
 
       currentPlaybackURL = url
-      avAsset = AVAsset(url: url)
+      avAsset = AVURLAsset(
+        url: url,
+        options: [
+          "AVURLAssetHTTPHeaderFieldsKey": buildAVPlayerHTTPHeaders(),
+        ]
+      )
     }
 
     currentAVAsset = avAsset
@@ -268,6 +275,25 @@ final class Player: NSObject {
   private func postPlaybackStatusUpdates() {
     delegate?.updatePlayback()
     updateNowPlayingPlaybackInfo()
+  }
+
+  private func buildAVPlayerHTTPHeaders() -> [String: String] {
+    return [
+      "User-Agent": self.userAgent,
+    ]
+  }
+
+  private static func buildUserAgent() -> String {
+    let processInfo = ProcessInfo()
+
+    var bundleVersion = ""
+    var bundleShortVersion = ""
+    if let infoDict = Bundle.main.infoDictionary {
+      bundleVersion = (infoDict["CFBundleVersion"] as? String) ?? ""
+      bundleShortVersion = (infoDict["CFBundleShortVersionString"] as? String) ?? ""
+    }
+
+    return "Doughnut/\(bundleShortVersion).\(bundleVersion) (+https://doughnutapp.com/; Podcast Client; macOS \(processInfo.operatingSystemVersionString))"
   }
 
   // MARK: - Actions


### PR DESCRIPTION
Closes #87.

As discussed in #87, this PR implements an identifiable User-Agent for media playback.

Checklist:
- [x] Compatibility test on macOS Catalina & Big Sur.

After merging this PR, user agent patterns should be submitted to [opawg/user-agents](https://github.com/opawg/user-agents) and [opawg/podcast-rss-useragents](https://github.com/opawg/podcast-rss-useragents). Simple regex patterns like `Doughnut` should be enough to distinguish Doughnut from other clients.