### PR TITLE
Support for subscribing podcasts.apple.com URLs.

### DIFF
--- a/Doughnut/Library/Podcast.swift
+++ b/Doughnut/Library/Podcast.swift
@@ -322,7 +322,7 @@ class Podcast: Record {
 
   // Detect either an iTunes podcast or RSS feed and call completion with resulting podcast
   static func detect(url: String, completion: @escaping (_ result: Podcast?) -> Void) -> Bool {
-    if url.contains("itunes.apple.com") {
+    if url.contains("itunes.apple.com") || url.contains("podcasts.apple.com") {
       return Utils.iTunesFeedUrl(iTunesUrl: url, completion: { (feedUrl) in
         guard let feedUrl = URL(string: feedUrl ?? "") else {
           return


### PR DESCRIPTION
Fixes #93.

This is a quick fix to allow parsing `podcasts.apple.com` URLs. Future versions will abstract the feed-detecting logic with protocols to make it easier to add support for other services.