### PR TITLE
Enable symbolication for PLCrashReporter

### DIFF
--- a/Doughnut/CrashReport/CrashReporter.swift
+++ b/Doughnut/CrashReport/CrashReporter.swift
@@ -31,7 +31,7 @@ final class CrashReporter {
   private var plCrashReporter: PLCrashReporter?
 
   private init() {
-    let config = PLCrashReporterConfig.defaultConfiguration()
+    let config = PLCrashReporterConfig(signalHandlerType: .BSD, symbolicationStrategy: .symbolTable)
     guard let plCrashReporter = PLCrashReporter(configuration: config) else {
       print("CrashReporter: could not create an instance of PLCrashReporter")
       return


### PR DESCRIPTION
This PR enables symbolication for PLCrashReporter to include symbol information for system frameworks in user-submitted crash reports.